### PR TITLE
Add support for headers in HTTP requests in MCP client

### DIFF
--- a/src/client/mcp-client.ts
+++ b/src/client/mcp-client.ts
@@ -127,8 +127,15 @@ export class MCPClient implements ToolProvider {
     async connectViaSSE(url: string, headers: Record<string, string>): Promise<Client> {
         logger.info(`Connecting to SSE MCP server at url: ${url}`);
 
-        this.transport = new SSEClientTransport(new URL(url));
-
+        this.transport = new SSEClientTransport(new URL(url), {
+            // For regular HTTP requests 
+            requestInit: {
+                headers: headers
+            }
+            // Need to implement eventSourceInit for SSE events.
+        });
+        
+        logger.debug(`[connectViaSSE] SSE transport: ${JSON.stringify(this.transport, null, 2)}`);
         this.client = new Client({
             name: 'Saiki-sse-mcp-client',
             version: '1.0.0'


### PR DESCRIPTION
This allows us to use custom headers from saiki.yml in our HTTP requests that are being sent to the MCP client (ex: calls to tools/list, prompts/list APIs would use HTTP 1 way requests).

Note: There are also other SSE based events that the MCP server sends back. To customize the headers for those, we will need to implement `eventSourceInit` while initializing the SSE transport. Need to check more in the MCP SDK

Resolves #19 