### PR TITLE
Add google LLMs into vercel LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ You can use `configuration/saiki.yml` directly, or you can use a custom configur
 npm start -- --config-file path/to/your/config.yml
 ```
 
+In order to use a different llm provider, change the llm section in the config.
+
 For detailed configuration options and examples, see the [Configuration Guide](./configuration/README.md).
 
 ## 🔌 Extensions

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -73,7 +73,7 @@ The `llm` section configures the AI provider settings.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `provider` | string | Yes | AI provider (e.g., "openai", "anthropic") |
+| `provider` | string | Yes | AI provider (e.g., "openai", "anthropic", "google") |
 | `model` | string | Yes | The model to use |
 | `apiKey` | string | Yes | API key or environment variable reference |
 | `providerOptions` | object | No | Provider-specific options like temperature and maxTokens |
@@ -85,6 +85,30 @@ You can specify the API key directly or reference an environment variable:
 ```yaml
 apiKey: sk-actual-api-key  # Direct specification (not recommended)
 apiKey: env:OPENAI_API_KEY  # Reference to environment variable
+```
+
+#### Openai example
+```yaml
+llm:
+  provider: openai
+  model: gpt-4o
+  apiKey: env:OPENAI_API_KEY
+```
+
+#### Anthropic example
+```yaml
+llm:
+  provider: anthropic
+  model: claude-3-7-sonnet-20250219
+  apiKey: env:ANTHROPIC_API_KEY
+```
+
+#### Google example
+```yaml
+llm:
+  provider: google
+  model: gemini-1.5-pro
+  apiKey: env:GOOGLE_GENERATIVE_AI_API_KEY
 ```
 
 ### Windows Support

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -107,7 +107,7 @@ llm:
 ```yaml
 llm:
   provider: google
-  model: gemini-1.5-pro
+  model: gemini-2.0-flash
   apiKey: env:GOOGLE_GENERATIVE_AI_API_KEY
 ```
 

--- a/configuration/examples/README.md
+++ b/configuration/examples/README.md
@@ -1,5 +1,5 @@
 # Configuration Examples
 
-This folder contains configuration examples for specialized agents dedicated to specific tasks. These examples demonstrate how to configure and set up various agent types to handle different use cases.
+This folder contains examples for agents with different configurations. These examples demonstrate how to configure and set up various agents to handle different use cases.
 
 You can directly plug in these configuration files and try them out on your local system to see the power of different AI Agents!

--- a/configuration/saiki.yml
+++ b/configuration/saiki.yml
@@ -15,14 +15,26 @@ mcpServers:
       - ts-node/esm
       - src/servers/puppeteerServer.ts
 
+# # describes the llm configuration
+# llm:
+#   provider: openai
+#   model: gpt-4o-mini
+#   # you can update the system prompt to change the behavior of the llm
+#   systemPrompt: |
+#     You are Saiki, a helpful AI assistant with access to tools.
+#     Use these tools when appropriate to answer user queries.
+#     You can use multiple tools in sequence to solve complex problems.
+#     After each tool result, determine if you need more information or can provide a final answer.
+#   apiKey: env:OPENAI_API_KEY
+
 # describes the llm configuration
 llm:
-  provider: openai
-  model: gpt-4o-mini
+  provider: google
+  model: gemini-2.0-flash
   # you can update the system prompt to change the behavior of the llm
   systemPrompt: |
     You are Saiki, a helpful AI assistant with access to tools.
     Use these tools when appropriate to answer user queries.
     You can use multiple tools in sequence to solve complex problems.
     After each tool result, determine if you need more information or can provide a final answer.
-  apiKey: env:OPENAI_API_KEY
+  apiKey: env:GOOGLE_GENERATIVE_AI_API_KEY

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/anthropic": "^1.2.2",
+                "@ai-sdk/google": "^1.2.8",
                 "@ai-sdk/openai": "^1.3.3",
                 "@anthropic-ai/sdk": "^0.39.0",
                 "@modelcontextprotocol/sdk": "^1.7.0",
@@ -62,6 +63,39 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.3.tgz",
             "integrity": "sha512-o3fWTzkxzI5Af7U7y794MZkYNEsxbjLam2nxyoUZSScqkacb7vZ3EYHLh21+xCcSSzEC161C7pZAGHtC0hTUMw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "1.1.0",
+                "nanoid": "^3.3.8",
+                "secure-json-parse": "^2.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.23.8"
+            }
+        },
+        "node_modules/@ai-sdk/google": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.8.tgz",
+            "integrity": "sha512-Q7Y71KGyH5sennNev5xZvt5MhxWlu+crp7tZZtdFbQ9iDkOGrl+TurPssqM0Wv5lYmV+Lc8m14CK9/k7nF2IRA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "1.1.0",
+                "@ai-sdk/provider-utils": "2.2.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.0.0"
+            }
+        },
+        "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.4.tgz",
+            "integrity": "sha512-13sEGBxB6kgaMPGOgCLYibF6r8iv8mgjhuToFrOTU09bBxbFQd8ZoARarCfJN6VomCUbUvMKwjTBLb1vQnN+WA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "license": "MIT",
     "dependencies": {
         "@ai-sdk/anthropic": "^1.2.2",
+        "@ai-sdk/google": "^1.2.8",
         "@ai-sdk/openai": "^1.3.3",
         "@anthropic-ai/sdk": "^0.39.0",
         "@modelcontextprotocol/sdk": "^1.7.0",

--- a/src/ai/llm/factory.ts
+++ b/src/ai/llm/factory.ts
@@ -3,7 +3,8 @@ import { ILLMService } from './types.js';
 import { LLMConfig } from '../../config/types.js';
 import { logger } from '../../utils/logger.js';
 import { openai } from '@ai-sdk/openai';
-import { anthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI, google } from '@ai-sdk/google';
+import { createAnthropic, anthropic } from '@ai-sdk/anthropic';
 import { VercelLLMService } from './vercel.js';
 import { VercelLLM } from './types.js';
 import { OpenAIService } from './openai.js';
@@ -79,6 +80,8 @@ function _createVercelModel(provider: string, model: string): any {
             return openai(model);
         case 'anthropic':
             return anthropic(model);
+        case 'google':
+            return google(model);
         default:
             throw new Error(`Unsupported LLM provider: ${provider}`);
     }

--- a/src/client/mcp-client.ts
+++ b/src/client/mcp-client.ts
@@ -127,8 +127,15 @@ export class MCPClient implements ToolProvider {
     async connectViaSSE(url: string, headers: Record<string, string>): Promise<Client> {
         logger.info(`Connecting to SSE MCP server at url: ${url}`);
 
-        this.transport = new SSEClientTransport(new URL(url));
-
+        this.transport = new SSEClientTransport(new URL(url), {
+            // For regular HTTP requests 
+            requestInit: {
+                headers: headers
+            }
+            // Need to implement eventSourceInit for SSE events.
+        });
+        
+        logger.debug(`[connectViaSSE] SSE transport: ${JSON.stringify(this.transport, null, 2)}`);
         this.client = new Client({
             name: 'Saiki-sse-mcp-client',
             version: '1.0.0'


### PR DESCRIPTION
This allows us to use gemini models as well with vercel llm provider.

Tested locally with gemini-1.5-pro and gemini-2.0-flash

Also updated READMEs to include example for gemini models