### PR TITLE
Refactor utils

### DIFF
--- a/src/ai/llm/services/vercel.ts
+++ b/src/ai/llm/services/vercel.ts
@@ -8,7 +8,8 @@ import { EventEmitter } from 'events';
 import { MessageManager } from '../messages/manager.js';
 import { VercelMessageFormatter } from '../messages/formatters/vercel.js';
 import { createTokenizer } from '../tokenizer/factory.js';
-import { getProviderFromModel, getMaxTokens } from '../tokenizer/utils.js';
+import { getMaxTokens } from '../tokenizer/utils.js';
+import { getProviderFromModel } from '../../utils.js';
 
 /**
  * Vercel implementation of LLMService

--- a/src/ai/utils.ts
+++ b/src/ai/utils.ts
@@ -1,0 +1,27 @@
+import { logger } from '../utils/logger.js';
+
+const MODEL_PREFIX_TO_PROVIDER: Record<string, string> = {
+    'gpt-': 'openai',
+    'claude-': 'anthropic',
+    'gemini-': 'google',
+    'grok-': 'grok',
+    // Add more as needed
+};
+
+/**
+ * Infers the LLM provider from the model name using a prefix-to-provider map.
+ * Matches the start of the model name against known prefixes for extensibility.
+ *
+ * @param model The model name (e.g., 'gpt-4o-mini', 'claude-3-7-sonnet-20250219')
+ * @returns The inferred provider name ('openai', 'anthropic', etc.), or 'unknown' if no match is found.
+ */
+export function getProviderFromModel(model: string): string {
+    const lowerModel = model.toLowerCase();
+    for (const prefix in MODEL_PREFIX_TO_PROVIDER) {
+        if (lowerModel.startsWith(prefix)) {
+            return MODEL_PREFIX_TO_PROVIDER[prefix];
+        }
+    }
+    logger.warn(`Could not determine provider for model: ${model}. Defaulting to 'unknown'.`);
+    return 'unknown';
+}

--- a/src/client/mcp-client.ts
+++ b/src/client/mcp-client.ts
@@ -17,7 +17,6 @@ const ToolsListSchema = z.object({
     nextCursor: z.string().optional(),
 });
 
-
 const DEFAULT_TIMEOUT = 60000;
 /**
  * Wrapper on top of Client class provided in model context protocol SDK, to add additional metadata about the server

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -12,9 +12,12 @@ import { logger } from '../utils/logger.js';
 // Expand $VAR and ${VAR} in all string values recursively
 function expandEnvVars(config: any): any {
     if (typeof config === 'string') {
-        const expanded = config.replace(/\$([A-Z_][A-Z0-9_]*)|\${([A-Z_][A-Z0-9_]*)}/gi, (_, v1, v2) => {
-            return process.env[v1 || v2] || '';
-        });
+        const expanded = config.replace(
+            /\$([A-Z_][A-Z0-9_]*)|\${([A-Z_][A-Z0-9_]*)}/gi,
+            (_, v1, v2) => {
+                return process.env[v1 || v2] || '';
+            }
+        );
         return expanded;
     } else if (Array.isArray(config)) {
         return config.map(expandEnvVars);


### PR DESCRIPTION
1. moved utils to more relevant files
2. utilizing dictionary to store metadata about models/providers instead of if-else trees

improves maintainability

tested with anthropic + openai in vercel + non vercel mode