### PR TITLE
Add support for docker and instructions for using docker in README.Docker.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG NODE_VERSION=20.18.1
+
+################################################################################
+# Use node image for base image for all stages.
+FROM node:${NODE_VERSION}-alpine AS base
+
+# Set working directory for all build stages.
+WORKDIR /usr/src/app
+
+
+################################################################################
+# Create a stage for installing production dependecies.
+FROM base AS deps
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.npm to speed up subsequent builds.
+# Leverage bind mounts to package.json and package-lock.json to avoid having to copy them
+# into this layer.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
+
+################################################################################
+# Create a stage for building the application.
+FROM deps AS build
+
+# Download additional development dependencies before building, as some projects require
+# "devDependencies" to be installed to build. If you don't need this, remove this step.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# Copy the rest of the source files into the image.
+COPY . .
+# Run the build script.
+RUN npm run build
+
+################################################################################
+# Create a new stage to run the application with minimal runtime dependencies
+# where the necessary files are copied from the build stage.
+FROM base AS final
+
+# Use production node environment by default.
+ENV NODE_ENV=production
+
+# Run the application as a non-root user.
+USER node
+
+# Copy package.json so that package manager commands can be used.
+COPY package.json .
+# Copy configuration files
+COPY configuration ./configuration
+
+# Copy the production dependencies from the deps stage and also
+# the built application from the build stage into the image.
+COPY --from=deps /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/dist ./dist
+
+
+# Expose the port that the application listens on.
+EXPOSE 3000
+
+# Run the application.
+ENTRYPOINT ["npm", "start"]
+CMD []

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,107 @@
+# Running Saiki with Docker
+
+This guide explains how to build and run Saiki using Docker, including advanced options for mounting your project directory and setting the working directory.
+
+---
+
+## 1. Build the Docker image
+
+Make sure Docker desktop is running and then run
+
+```bash
+docker build -t saiki .
+```
+
+## 2. Prepare your environment
+
+Make sure you have a `.env` file in your project root with your API keys (see the main README for details).
+
+## 3. Run Saiki in CLI mode (interactive)
+
+```bash
+docker run -it --env-file .env saiki
+```
+- The `-it` flag gives you an interactive terminal for the CLI.
+- You can also pass CLI arguments, for example:
+  ```bash
+  docker run -it --env-file .env saiki -- --config-file configuration/saiki.yml
+  ```
+
+## 4. Run Saiki in Web UI mode
+
+```bash
+docker run --env-file .env -p 3000:3000 saiki -- --mode web
+```
+- Access the Web UI at [http://localhost:3000](http://localhost:3000).
+- To use a custom port:
+  ```bash
+  docker run --env-file .env -p 8080:8080 saiki -- --mode web --web-port 8080
+  ```
+
+## 5. (Optional) Mount your project directory and set the working directory
+
+If you want Saiki (and its MCP servers) to access files from your host machine, you can mount your project directory into the container and set the working directory at runtime:
+
+**On Linux/macOS:**
+```bash
+docker run -it --env-file .env -v ~/Projects/saiki:/workspace -w /workspace saiki
+```
+- `-v ~/Projects/saiki:/workspace` mounts your local project directory into the container at `/workspace`.
+- `-w /workspace` sets the working directory inside the container to `/workspace`.
+
+**On Windows (Command Prompt):**
+```cmd
+docker run -it --env-file .env -v C:\Users\<YourUsername>\Projects\saiki:/workspace -w /workspace saiki
+```
+- Use your actual Windows username and path.
+- If using PowerShell, you may need to quote the path:
+  ```powershell
+  docker run -it --env-file .env -v "C:\Users\<YourUsername>\Projects\saiki:/workspace" -w /workspace saiki
+  ```
+- If using Git Bash or WSL, you may use `/c/Users/<YourUsername>/Projects/saiki:/workspace` as the path.
+
+This allows Saiki and its tool servers (like Filesystem MCP) to see and operate on your local files, just like when running outside Docker.
+
+## 6. Passing Environment Variables (e.g., API keys)
+
+You can also pass environment variables directly:
+
+```bash
+docker run -e OPENAI_API_KEY=your_openai_api_key -p 3000:3000 saiki -- --mode web
+```
+
+## 7. Docker Compose & Cloud Deployment
+
+### Docker Compose
+
+When you're ready, you can start your application with Docker Compose.
+You can update compose.yaml accordingly based on the containers you want, we have a sample file to get started.
+
+```bash
+docker compose up --build
+```
+
+Your application will be available at http://localhost:3000.
+
+You can also override the command in Docker Compose using the `command:` field.
+
+### Deploying to the Cloud
+
+First, build your image for the appropriate platform (if needed):
+
+```bash
+docker build --platform=linux/amd64 -t myapp .
+```
+
+Then, push it to your registry:
+
+```bash
+docker push myregistry.com/myapp
+```
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/) docs for more detail on building and pushing images.
+
+## 8. References
+
+- [Docker's Node.js guide](https://docs.docker.com/language/nodejs/)
+- See the main [README.md](./README.md) for more details on configuration and usage.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ OPENAI_API_KEY=your_openai_api_key_here
 
    That's it! You're now ready to interact with Saiki through the command line or web interface.
 
+   Saiki also works with Docker — see the [Running with Docker](#running-with-docker) section below for details.
+
+---
+
+### Running with Docker
+
+See [README.Docker.md](./README.Docker.md) for detailed instructions on building and running Saiki with Docker, including mounting your project directory and setting the working directory at runtime.
+
+---
+
 ### Next Steps
 Check out [example configurations](./configuration/examples/) or the [Configuration Guide](./configuration/README.md) to customize your setup.
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -22,12 +22,20 @@ const program = new Command();
 
 // Check if .env file exists
 if (!existsSync('.env')) {
-    logger.error('ERROR: .env file not found.');
-    logger.info('Please create a .env file with your OpenAI API key.');
-    logger.info('You can copy .env.example and fill in your API key.');
+    logger.warn('WARNING: .env file not found.');
+    logger.info('If you are running locally, please create a .env file with your API key(s).');
+    logger.info('You can copy .env.example and fill in your API key(s).');
+    logger.info('Alternatively, ensure the required environment variables are set.');
     logger.info('');
     logger.info('Example .env content:');
     logger.info('OPENAI_API_KEY=your_openai_api_key_here', null, 'green');
+    logger.info('GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key_here', null, 'green');
+    logger.info('ANTHROPIC_API_KEY=your_anthropic_api_key_here', null, 'green');
+}
+
+// Check for at least one required API key
+if (!process.env.OPENAI_API_KEY && !process.env.GOOGLE_GENERATIVE_AI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
+    logger.error('ERROR: No API key found. Please set at least one of OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or ANTHROPIC_API_KEY in your environment or .env file.');
     process.exit(1);
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,53 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  server:
+    build:
+      context: .
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+    ports:
+      - 3000:3000
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker-compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt
+

--- a/configuration/saiki.yml
+++ b/configuration/saiki.yml
@@ -11,9 +11,7 @@ mcpServers:
     type: stdio
     command: node
     args:
-      - --loader
-      - ts-node/esm
-      - src/servers/puppeteerServer.ts
+      - dist/src/servers/puppeteerServer.js
 
 # # describes the llm configuration
 llm:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
         "lib": ["ES2022", "DOM"]
     },
     "include": ["src/**/*", "app/**/*"],
-    "exclude": ["node_modules", "src/servers/**/*"]
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Resolves #17 

Added `Dockerfile` for supporting `docker build` and `docker run`
Added sample `compose.yaml` file for using `docker compose`.
Added instructions for using docker in `README.Docker.md`
Added `.dockerignore` to exclude files from the docker image.

Updated tsconfig.json to include `src/servers` files in the build. Also updated saiki.yml to use the raw js for running the puppeteerServer instead of ts-node to run typescript directly - this is for easier docker support and also improved performance [running js directly is faster than running ts which anyway gets compiled to js]

This enables us to save Saiki agent configs as docker images and run them anywhere.

Next steps could be exposing the agent as callable APIs and adding webhooks to subscribe to agent events instead of subscribing within the container.

