### PR TITLE
Update package.json to support 'saiki' command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "saiki",
             "version": "0.1.0",
-            "license": "MIT",
+            "license": "Elastic-2.0",
             "dependencies": {
                 "@ai-sdk/anthropic": "^1.2.2",
                 "@ai-sdk/google": "^1.2.8",
@@ -30,6 +30,9 @@
                 "ws": "^8.18.1",
                 "yaml": "^2.7.1",
                 "zod": "^3.22.4"
+            },
+            "bin": {
+                "saiki": "dist/app/index.js"
             },
             "devDependencies": {
                 "@eslint/js": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
     "description": "Your command center for controlling computers and services with natural language - connect once, command everything",
     "type": "module",
     "main": "dist/app/index.js",
+    "bin": {
+        "saiki": "./dist/app/index.js"
+    },
     "scripts": {
         "clean": "rimraf dist",
         "prebuild": "npm run lint",
         "build": "npm run clean && tsc && npm run copy-client",
+        "prepare": "npm run build",
         "copy-client": "rimraf public && mkdir public && copyfiles -f \"app/web/client/*\" public",
         "start": "node dist/app/index.js",
         "dev": "tsc --watch",
@@ -26,7 +30,7 @@
         "truffle-ai"
     ],
     "author": "",
-    "license": "MIT",
+    "license": "Elastic-2.0",
     "dependencies": {
         "@ai-sdk/anthropic": "^1.2.2",
         "@ai-sdk/google": "^1.2.8",


### PR DESCRIPTION
with this, we can now install saiki and access saiki anywhere in the terminal without git cloning!

also fixed the license metadata in package.json

Steps:

1. `npm install -g truffle-ai/saiki`

This step clones the repo and runs the `prepare` script to produce `dist` files. 
updating `package.json` allows users to 

2. use Saiki via CLI

in terminal mode:

```
saiki
```

in web mode:

```
saiki --mode web
```

to get help:
```
saiki --help
```


next steps:
1. publish our package to npm registry and change `npm install -g truffle-ai/saiki` to `npm install -g @truffle-ai/saiki`
in first cmd - user is pulling from the tip of main, in second cmd, user is pulling binaries from officially published npm version, so we can ensure reliability

