### PR TITLE
add npx before rimraf and copyfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "saiki": "./dist/app/index.js"
     },
     "scripts": {
-        "clean": "rimraf dist",
+        "clean": "npx rimraf dist",
         "prebuild": "",
-        "build": "npm run clean && tsc && npm run copy-client",
+        "build": "npm run clean && npx tsc && npm run copy-client",
         "prepare": "npm run build",
-        "copy-client": "rimraf public && mkdir public && copyfiles -f \"app/web/client/*\" public",
+        "copy-client": "npx rimraf public && mkdir public && npx copyfiles -f \"app/web/client/*\" public",
         "start": "node dist/app/index.js",
         "dev": "tsc --watch",
         "lint": "eslint . --ext .ts",
@@ -41,6 +41,7 @@
         "boxen": "^7.1.1",
         "chalk": "^5.4.1",
         "commander": "^11.1.0",
+        "copyfiles": "^2.4.1",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "marked": "^15.0.8",
@@ -48,14 +49,13 @@
         "ora": "^7.0.1",
         "puppeteer-core": "^24.4.0",
         "readline-sync": "^1.4.10",
+        "rimraf": "^6.0.1",
         "tiktoken": "^1.0.20",
+        "typescript": "^5.3.3",
         "winston": "^3.17.0",
         "ws": "^8.18.1",
         "yaml": "^2.7.1",
-        "zod": "^3.22.4",
-        "rimraf": "^6.0.1",
-        "copyfiles": "^2.4.1",
-        "typescript": "^5.3.3"
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@eslint/js": "^9.23.0",


### PR DESCRIPTION
this should avoid this error:

```
[  9:01PM ]  [ karaj@mac:~ ]
 $ npm install -g truffle-ai/saiki
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm error code 127
npm error git dep preparation failed
npm error command /Users/karaj/.nvm/versions/node/v20.18.1/bin/node /Users/karaj/.nvm/versions/node/v20.18.1/lib/node_modules/npm/bin/npm-cli.js install --force --cache=/Users/karaj/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
npm error npm warn using --force Recommended protections disabled.
npm error npm error code 127
npm error npm error path /Users/karaj/.npm/_cacache/tmp/git-cloneYZtM2i
npm error npm error command failed
npm error npm error command sh -c npm run build
npm error npm error > saiki@0.1.0 build
npm error npm error > npm run clean && tsc && npm run copy-client
npm error npm error
npm error npm error
npm error npm error > saiki@0.1.0 clean
npm error npm error > rimraf dist
npm error npm error npm warn using --force Recommended protections disabled.
npm error npm error npm warn using --force Recommended protections disabled.
npm error npm error sh: rimraf: command not found
npm error npm error A complete log of this run can be found in: /Users/karaj/.npm/_logs/2025-04-17T04_02_12_699Z-debug-0.log
npm error A complete log of this run can be found in: /Users/karaj/.npm/_logs/2025-04-17T04_01_39_703Z-debug-0.log
```

need to merge to test