### PR TITLE
Updates for saiki CLI

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import dotenv from 'dotenv';
 import { logger } from '../src/utils/logger.js';
 import { loadConfigFile } from '../src/config/loader.js';
+import { DEFAULT_CONFIG_PATH, resolvePackagePath } from '../src/utils/path.js';
 import { AgentConfig } from '../src/config/types.js';
 import { initializeServices } from '../src/utils/service-initializer.js';
 import { runAiCli } from './cli/cli.js';
@@ -22,15 +23,15 @@ const program = new Command();
 
 // Check if .env file exists
 if (!existsSync('.env')) {
-    logger.warn('WARNING: .env file not found.');
-    logger.info('If you are running locally, please create a .env file with your API key(s).');
-    logger.info('You can copy .env.example and fill in your API key(s).');
-    logger.info('Alternatively, ensure the required environment variables are set.');
-    logger.info('');
-    logger.info('Example .env content:');
-    logger.info('OPENAI_API_KEY=your_openai_api_key_here', null, 'green');
-    logger.info('GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key_here', null, 'green');
-    logger.info('ANTHROPIC_API_KEY=your_anthropic_api_key_here', null, 'green');
+    logger.debug('WARNING: .env file not found.');
+    logger.debug('If you are running locally, please create a .env file with your API key(s).');
+    logger.debug('You can copy .env.example and fill in your API key(s).');
+    logger.debug('Alternatively, ensure the required environment variables are set.');
+    logger.debug('');
+    logger.debug('Example .env content:');
+    logger.debug('OPENAI_API_KEY=your_openai_api_key_here', null, 'green');
+    logger.debug('GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key_here', null, 'green');
+    logger.debug('ANTHROPIC_API_KEY=your_anthropic_api_key_here', null, 'green');
 }
 
 // Check for at least one required API key
@@ -49,7 +50,7 @@ if (
 program
     .name('saiki')
     .description('AI-powered CLI and WebUI for interacting with MCP servers')
-    .option('-c, --config-file <path>', 'Path to config file', 'configuration/saiki.yml')
+    .option('-c, --config-file <path>', 'Path to config file', DEFAULT_CONFIG_PATH)
     .option('-s, --strict', 'Require all server connections to succeed')
     .option('--no-verbose', 'Disable verbose output')
     .option('--mode <mode>', 'Run mode: cli or web', 'cli')
@@ -64,6 +65,7 @@ const configFile = options.configFile;
 const connectionMode = options.strict ? 'strict' : ('lenient' as 'strict' | 'lenient');
 const runMode = options.mode.toLowerCase();
 const webPort = parseInt(options.webPort, 10);
+const resolveFromPackageRoot = configFile === DEFAULT_CONFIG_PATH; // Check if should resolve from package root
 
 // Validate run mode
 if (!['cli', 'web'].includes(runMode)) {
@@ -78,7 +80,7 @@ if (isNaN(webPort) || webPort <= 0 || webPort > 65535) {
 }
 
 // Platform-independent path handling
-const normalizedConfigPath = path.normalize(configFile);
+const normalizedConfigPath = resolvePackagePath(configFile, resolveFromPackageRoot);
 
 logger.info(`Initializing Saiki with config: ${normalizedConfigPath}`, null, 'blue');
 

--- a/app/web/server.ts
+++ b/app/web/server.ts
@@ -7,6 +7,7 @@ import { ClientManager } from '../../src/client/manager.js';
 import { ILLMService } from '../../src/ai/llm/services/types.js';
 import { AgentEventManager } from '../../src/ai/llm/events/event-manager.js';
 import { logger } from '../../src/utils/logger.js'; // Import logger
+import { resolvePackagePath } from '../../src/utils/path.js';
 
 export async function initializeWebUI(
     clientManager: ClientManager,
@@ -23,8 +24,8 @@ export async function initializeWebUI(
     eventManager.registerSubscriber(webSubscriber);
     logger.info('WebUI Event Manager and Subscriber initialized.');
 
-    // Serve static files from the root /public directory
-    const publicPath = path.resolve(process.cwd(), 'public');
+    // Serve static files from the package's public directory using the helper
+    const publicPath = resolvePackagePath('public', true);
     logger.info(`Serving static files from: ${publicPath}`);
     app.use(express.static(publicPath));
 

--- a/configuration/examples/website_designer.yml
+++ b/configuration/examples/website_designer.yml
@@ -11,9 +11,7 @@ mcpServers:
     type: stdio
     command: node
     args:
-      - --loader
-      - ts-node/esm
-      - src/servers/puppeteerServer.ts
+      - dist/src/servers/puppeteerServer.js
 
 # # describes the llm configuration
 llm:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "saiki",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Your command center for controlling computers and services with natural language - connect once, command everything",
     "type": "module",
     "main": "dist/app/index.js",
@@ -31,6 +31,11 @@
     ],
     "author": "",
     "license": "Elastic-2.0",
+    "files": [
+        "dist/",
+        "configuration/saiki.yml",
+        "public/"
+    ],
     "dependencies": {
         "@ai-sdk/anthropic": "^1.2.2",
         "@ai-sdk/google": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "saiki": "./dist/app/index.js"
     },
     "scripts": {
-        "clean": "rimraf dist",
+        "clean": "npx rimraf dist",
         "prebuild": "",
-        "build": "npm run clean && tsc && npm run copy-client",
+        "build": "npm run clean && npx tsc && npm run copy-client",
         "prepare": "npm run build",
-        "copy-client": "rimraf public && mkdir public && copyfiles -f \"app/web/client/*\" public",
+        "copy-client": "npx rimraf public && mkdir public && npx copyfiles -f \"app/web/client/*\" public",
         "start": "node dist/app/index.js",
         "dev": "tsc --watch",
         "lint": "eslint . --ext .ts",
@@ -41,6 +41,7 @@
         "boxen": "^7.1.1",
         "chalk": "^5.4.1",
         "commander": "^11.1.0",
+        "copyfiles": "^2.4.1",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "marked": "^15.0.8",
@@ -48,14 +49,13 @@
         "ora": "^7.0.1",
         "puppeteer-core": "^24.4.0",
         "readline-sync": "^1.4.10",
+        "rimraf": "^6.0.1",
         "tiktoken": "^1.0.20",
+        "typescript": "^5.3.3",
         "winston": "^3.17.0",
         "ws": "^8.18.1",
         "yaml": "^2.7.1",
-        "zod": "^3.22.4",
-        "rimraf": "^6.0.1",
-        "copyfiles": "^2.4.1",
-        "typescript": "^5.3.3"
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@eslint/js": "^9.23.0",

--- a/src/client/mcp-client.ts
+++ b/src/client/mcp-client.ts
@@ -81,6 +81,7 @@ export class MCPClient implements ToolProvider {
         this.serverAlias = serverAlias || null;
 
         // --- Resolve path for bundled node scripts ---
+        // TODO: Improve this logic to be less hacky
         if (command === 'node' && this.resolvedArgs.length > 0 && this.resolvedArgs[0].startsWith('dist/')) {
             try {
                 const scriptRelativePath = this.resolvedArgs[0];

--- a/src/client/mcp-client.ts
+++ b/src/client/mcp-client.ts
@@ -2,10 +2,14 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { z } from 'zod';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { logger } from '../utils/logger.js';
 import { McpServerConfig, StdioServerConfig, SSEServerConfig } from '../config/types.js';
 import { ToolSet } from '../ai/types.js';
 import { ToolProvider } from './types.js';
+import { resolvePackagePath } from '../utils/path.js';
+
 const ToolsListSchema = z.object({
     tools: z.array(
         z.object({
@@ -26,7 +30,8 @@ export class MCPClient implements ToolProvider {
     private transport: any = null;
     private isConnected = false;
     private serverCommand: string | null = null;
-    private serverArgs: string[] | null = null;
+    private originalArgs: string[] | null = null;
+    private resolvedArgs: string[] | null = null;
     private serverEnv: Record<string, string> | null = null;
     private serverSpawned = false;
     private serverPid: number | null = null;
@@ -70,13 +75,25 @@ export class MCPClient implements ToolProvider {
     ): Promise<Client> {
         // Store server details
         this.serverCommand = command;
-        this.serverArgs = args;
+        this.originalArgs = [...args];
+        this.resolvedArgs = [...this.originalArgs];
         this.serverEnv = env || null;
         this.serverAlias = serverAlias || null;
 
-        logger.info('');
+        // --- Resolve path for bundled node scripts ---
+        if (command === 'node' && this.resolvedArgs.length > 0 && this.resolvedArgs[0].startsWith('dist/')) {
+            try {
+                const scriptRelativePath = this.resolvedArgs[0];
+                this.resolvedArgs[0] = resolvePackagePath(scriptRelativePath, true);
+                logger.debug(`Resolved bundled script path: ${scriptRelativePath} -> ${this.resolvedArgs[0]}`);
+            } catch (e) {
+                logger.warn(`Failed to resolve path for bundled script ${this.resolvedArgs[0]}: ${e}`);
+            }
+        }
+        // --- End path resolution ---
+
         logger.info('=======================================');
-        logger.info(`MCP SERVER: ${command} ${args.join(' ')}`, null, 'magenta');
+        logger.info(`MCP SERVER: ${command} ${this.resolvedArgs.join(' ')}`, null, 'magenta');
         if (env) {
             logger.info('Environment:');
             Object.entries(env).forEach(([key, _]) => {
@@ -85,9 +102,9 @@ export class MCPClient implements ToolProvider {
         }
         logger.info('=======================================\n');
 
-        const serverName = serverAlias
-            ? `"${serverAlias}" (${command} ${args.join(' ')})`
-            : `${command} ${args.join(' ')}`;
+        const serverName = this.serverAlias
+            ? `"${this.serverAlias}" (${command} ${this.resolvedArgs.join(' ')})`
+            : `${command} ${this.resolvedArgs.join(' ')}`;
         logger.info(`Connecting to MCP server: ${serverName}`);
 
         // Create a properly expanded environment by combining process.env with the provided env
@@ -98,8 +115,8 @@ export class MCPClient implements ToolProvider {
 
         // Create transport for stdio connection with expanded environment
         this.transport = new StdioClientTransport({
-            command,
-            args,
+            command: command,
+            args: this.resolvedArgs,
             env: expandedEnv as Record<string, string>,
         });
 
@@ -270,7 +287,8 @@ export class MCPClient implements ToolProvider {
         spawned: boolean;
         pid: number | null;
         command: string | null;
-        args: string[] | null;
+        originalArgs: string[] | null;
+        resolvedArgs: string[] | null;
         env: Record<string, string> | null;
         alias: string | null;
     } {
@@ -278,7 +296,8 @@ export class MCPClient implements ToolProvider {
             spawned: this.serverSpawned,
             pid: this.serverPid,
             command: this.serverCommand,
-            args: this.serverArgs,
+            originalArgs: this.originalArgs,
+            resolvedArgs: this.resolvedArgs,
             env: this.serverEnv,
             alias: this.serverAlias,
         };
@@ -300,7 +319,7 @@ export class MCPClient implements ToolProvider {
         // If connection is in progress, wait for it to complete
         return this.connectViaStdio(
             this.serverCommand,
-            this.serverArgs || [],
+            this.originalArgs || [],
             this.serverEnv || undefined,
             this.serverAlias || undefined
         );

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,8 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { parse as parseYaml } from 'yaml';
 import { AgentConfig } from './types.js';
 import { logger } from '../utils/logger.js';
+import { resolvePackagePath, DEFAULT_CONFIG_PATH } from '../utils/path.js';
 /**
  * Load the complete agent configuration
  * @param configPath Path to the configuration file
@@ -31,12 +33,15 @@ function expandEnvVars(config: any): any {
     return config;
 }
 
-export async function loadConfigFile(configPath: string): Promise<AgentConfig> {
+export async function loadConfigFile(
+    configPath: string
+): Promise<AgentConfig> {
     try {
-        // Make path absolute if it's relative
-        const absolutePath = path.isAbsolute(configPath)
-            ? configPath
-            : path.resolve(process.cwd(), configPath);
+        // Determine where to load from: absolute, default, or user-relative
+        const resolveFromPackageRoot = configPath === DEFAULT_CONFIG_PATH;
+        const absolutePath = resolvePackagePath(configPath, resolveFromPackageRoot);
+
+        logger.debug(`Attempting to load config from: ${absolutePath}`);
 
         // Read and parse the config file
         const fileContent = await fs.readFile(absolutePath, 'utf-8');
@@ -50,9 +55,11 @@ export async function loadConfigFile(configPath: string): Promise<AgentConfig> {
         } catch (parseError) {
             throw new Error(`Failed to parse YAML: ${parseError.message}`);
         }
-    } catch (error) {
+    } catch (error: any) {
+        // Include path & cause for better diagnostics
         throw new Error(
-            `Failed to load config file: ${error instanceof Error ? error.message : String(error)}`
+            `Failed to load config file at ${error.path || configPath}: ${error.message}`,
+            { cause: error }
         );
     }
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+
+/**
+ * Default config file path (relative to package root)
+ */
+export const DEFAULT_CONFIG_PATH = 'configuration/saiki.yml';
+
+/**
+ * Resolve the configuration file path.
+ * - If it's absolute, return as-is.
+ * - If it's the default config, resolve relative to the package installation root.
+ * - Otherwise resolve relative to the current working directory.
+ */
+export function resolvePackagePath(targetPath: string, resolveFromPackageRoot: boolean): string {
+    if (path.isAbsolute(targetPath)) {
+        return targetPath;
+    }
+    if (resolveFromPackageRoot) {
+        // Resolve relative to the package root by locating package.json upwards
+        const scriptPath = fileURLToPath(import.meta.url);
+        let dir = path.dirname(scriptPath);
+        while (true) {
+            const pkgPath = path.join(dir, 'package.json');
+            if (fs.existsSync(pkgPath)) {
+                return path.resolve(dir, targetPath);
+            }
+            const parent = path.dirname(dir);
+            if (parent === dir) {
+                throw new Error(`Cannot find package root when resolving default path: ${targetPath}`);
+            }
+            dir = parent;
+        }
+    }
+    // User-specified relative path
+    return path.resolve(process.cwd(), targetPath);
+} 


### PR DESCRIPTION
1. Add new file path util for figuring out relative paths from root directory - this is useful for the bundled installation and setting defaults.
2. set .env related logging to debug for now - might remove later because it is noisy
3. update any files reading filepaths to use the new util function.
4. bump up saiki version to 0.2.0
5. update puppeteer server to use dist with raw js instead of trying to compile ts (this is faster and better)
6. add check into mcp-client to deal with node dist combination. [this is a bit hacky and unclean but will fix it later]

Figured out how to test saiki CLI locally using npm link - works!