### PR TITLE
Move service initializations into service-initializer.ts

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -108,7 +108,7 @@ async function startAgent() {
         logger.info('===============================================\n');
 
         // Use the shared initializer
-        const { clientManager, llmService, agentEventBus } = await initializeServices(config, connectionMode);
+        const { clientManager, llmService, agentEventBus } = await initializeServices(config, { connectionMode });
 
         // Start based on mode
         if (runMode === 'cli') {

--- a/app/index.ts
+++ b/app/index.ts
@@ -108,7 +108,7 @@ async function startAgent() {
         logger.info('===============================================\n');
 
         // Use the shared initializer
-        const { clientManager, llmService, agentEventBus } = await initializeServices(config, { connectionMode });
+        const { clientManager, llmService, agentEventBus } = await initializeServices(config, { connectionMode, runMode });
 
         // Start based on mode
         if (runMode === 'cli') {

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { existsSync } from 'fs';
 import { Command } from 'commander';
-import path from 'path';
 import dotenv from 'dotenv';
 import { logger } from '../src/utils/logger.js';
 import { loadConfigFile } from '../src/config/loader.js';

--- a/src/ai/llm/messages/factory.ts
+++ b/src/ai/llm/messages/factory.ts
@@ -1,0 +1,56 @@
+import { MessageManager } from './manager.js';
+import { VercelMessageFormatter } from './formatters/vercel.js';
+import { OpenAIMessageFormatter } from './formatters/openai.js';
+import { AnthropicMessageFormatter } from './formatters/anthropic.js';
+import { createTokenizer } from '../tokenizer/factory.js';
+import { getMaxTokens } from '../tokenizer/utils.js';
+import { LLMConfig } from '../../../config/types.js';
+import { LLMRouter } from '../types.js';
+import { IMessageFormatter } from './formatters/types.js';
+import { ITokenizer } from '../tokenizer/types.js';
+
+/**
+ * Factory function to create a MessageManager instance with the correct formatter, tokenizer, and maxTokens
+ * based on the LLM config and router (vercel, default, or future types).
+ *
+ * @param config LLMConfig object containing provider, model, systemPrompt, etc.
+ * @param router LLMRouter flag ('vercel', 'default', etc.)
+ * @returns MessageManager instance
+ */
+export function createMessageManager(
+    config: LLMConfig,
+    router: LLMRouter = 'vercel'
+): MessageManager {
+    let formatter: IMessageFormatter;
+    let tokenizer: ITokenizer;
+    let maxTokens: number;
+    const provider = config.provider.toLowerCase();
+    const model = config.model;
+
+    if (router === 'vercel') {
+        formatter = new VercelMessageFormatter();
+        tokenizer = createTokenizer(provider, model);
+        maxTokens = Math.floor(getMaxTokens(provider, model) * 0.9);
+    } else if (router === 'default') {
+        if (provider === 'openai') {
+            formatter = new OpenAIMessageFormatter();
+            tokenizer = createTokenizer('openai', model);
+            maxTokens = Math.floor(getMaxTokens('openai', model) * 0.9);
+        } else if (provider === 'anthropic') {
+            formatter = new AnthropicMessageFormatter();
+            tokenizer = createTokenizer('anthropic', model);
+            maxTokens = Math.floor(getMaxTokens('anthropic', model) * 0.9);
+        } else {
+            throw new Error(`Unsupported LLM provider: ${provider} for router: ${router}`);
+        }
+    } else {
+        throw new Error(`Unsupported LLM router: ${router}`);
+    }
+
+    return new MessageManager(
+        formatter,
+        config.systemPrompt ?? null,
+        maxTokens,
+        tokenizer
+    );
+} 

--- a/src/ai/llm/messages/factory.ts
+++ b/src/ai/llm/messages/factory.ts
@@ -50,7 +50,7 @@ export function createMessageManager(
 
     return new MessageManager(
         formatter,
-        config.systemPrompt ?? null,
+        config.systemPrompt,
         maxTokens,
         tokenizer
     );

--- a/src/ai/llm/messages/factory.ts
+++ b/src/ai/llm/messages/factory.ts
@@ -16,6 +16,7 @@ import { ITokenizer } from '../tokenizer/types.js';
  * @param config LLMConfig object containing provider, model, systemPrompt, etc.
  * @param router LLMRouter flag ('vercel', 'default', etc.)
  * @returns MessageManager instance
+ * TODO: Make compression strategy also configurable
  */
 export function createMessageManager(
     config: LLMConfig,

--- a/src/ai/llm/messages/manager.ts
+++ b/src/ai/llm/messages/manager.ts
@@ -356,4 +356,24 @@ export class MessageManager {
             }
         }
     }
+
+    /**
+     * Parses a raw LLM response, converts it into internal messages and adds them to the history.
+     *
+     * @param response The response from the LLM provider
+     */
+    processLLMResponse(response: any): void {
+        const msgs = this.formatter.parseResponse(response) ?? [];
+        msgs.forEach((m) => this.addMessage(m));
+    }
+
+    /**
+     * Returns the current token count of the conversation history.
+     *
+     * @returns The number of tokens in the current history, or 0 if no tokenizer is set
+     */
+    getTokenCount(): number {
+        if (!this.tokenizer) return 0;
+        return countMessagesTokens(this.history, this.tokenizer);
+    }
 }

--- a/src/ai/llm/messages/manager.ts
+++ b/src/ai/llm/messages/manager.ts
@@ -376,4 +376,11 @@ export class MessageManager {
         if (!this.tokenizer) return 0;
         return countMessagesTokens(this.history, this.tokenizer);
     }
+
+    /**
+     * Returns the configured maximum number of tokens for the conversation, or null if not set.
+     */
+    getMaxTokens(): number | null {
+        return this.maxTokens;
+    }
 }

--- a/src/ai/llm/messages/utils.ts
+++ b/src/ai/llm/messages/utils.ts
@@ -91,8 +91,10 @@ export function getImageData(imagePart: { image: string | Uint8Array | Buffer | 
         return image;
     } else if (image instanceof Buffer) {
         return image.toString('base64');
-    } else if (image instanceof Uint8Array || image instanceof ArrayBuffer) {
+    } else if (image instanceof Uint8Array) {
         return Buffer.from(image).toString('base64');
+    } else if (image instanceof ArrayBuffer) {
+        return Buffer.from(new Uint8Array(image)).toString('base64');
     } else if (image instanceof URL) {
         return image.toString();
     }

--- a/src/ai/llm/messages/utils.ts
+++ b/src/ai/llm/messages/utils.ts
@@ -2,7 +2,7 @@ import { InternalMessage } from './types.js';
 import { ITokenizer } from '../tokenizer/types.js';
 
 // Approximation for message format overhead
-export const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
+const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
 
 /**
  * Counts the total tokens in an array of InternalMessages using a provided tokenizer.

--- a/src/ai/llm/messages/utils.ts
+++ b/src/ai/llm/messages/utils.ts
@@ -2,7 +2,7 @@ import { InternalMessage } from './types.js';
 import { ITokenizer } from '../tokenizer/types.js';
 
 // Approximation for message format overhead
-const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
+export const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
 
 /**
  * Counts the total tokens in an array of InternalMessages using a provided tokenizer.

--- a/src/ai/llm/services/anthropic.ts
+++ b/src/ai/llm/services/anthropic.ts
@@ -22,27 +22,16 @@ export class AnthropicService implements ILLMService {
 
     constructor(
         clientManager: ClientManager,
-        systemPrompt: string,
-        apiKey: string,
+        anthropic: Anthropic,
         agentEventBus: EventEmitter,
-        model?: string
+        messageManager: MessageManager,
+        model: string
     ) {
-        this.model = model || 'claude-3-7-sonnet-20250219';
-        this.anthropic = new Anthropic({ apiKey });
+        this.model = model;
+        this.anthropic = anthropic;
         this.clientManager = clientManager;
-
-        const formatter = new AnthropicMessageFormatter();
-        const tokenizer = createTokenizer('anthropic', this.model);
-        const rawMaxTokens = getMaxTokens('anthropic', this.model);
-        const maxTokensWithMargin = Math.floor(rawMaxTokens * 0.9);
-        this.messageManager = new MessageManager(
-            formatter,
-            systemPrompt,
-            maxTokensWithMargin,
-            tokenizer
-        );
-
         this.eventEmitter = agentEventBus;
+        this.messageManager = messageManager;
     }
 
     getEventEmitter(): EventEmitter {

--- a/src/ai/llm/services/anthropic.ts
+++ b/src/ai/llm/services/anthropic.ts
@@ -33,10 +33,8 @@ export class AnthropicService implements ILLMService {
 
         const formatter = new AnthropicMessageFormatter();
         const tokenizer = createTokenizer('anthropic', this.model);
-
         const rawMaxTokens = getMaxTokens('anthropic', this.model);
         const maxTokensWithMargin = Math.floor(rawMaxTokens * 0.9);
-
         this.messageManager = new MessageManager(
             formatter,
             systemPrompt,

--- a/src/ai/llm/services/anthropic.ts
+++ b/src/ai/llm/services/anthropic.ts
@@ -1,12 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { ClientManager } from '../../../client/manager.js';
-import { ILLMService } from './types.js';
+import { ILLMService, LLMServiceConfig } from './types.js';
 import { ToolSet } from '../../types.js';
 import { logger } from '../../../utils/logger.js';
 import { EventEmitter } from 'events';
 import { MessageManager } from '../messages/manager.js';
-import { AnthropicMessageFormatter } from '../messages/formatters/anthropic.js';
-import { createTokenizer } from '../tokenizer/factory.js';
 import { getMaxTokens } from '../tokenizer/utils.js';
 import { ImageData } from '../messages/types.js';
 
@@ -192,8 +190,8 @@ export class AnthropicService implements ILLMService {
      * Get configuration information about the LLM service
      * @returns Configuration object with provider and model information
      */
-    getConfig(): { provider: string; model: string; [key: string]: any } {
-        const configuredMaxTokens = (this.messageManager as any).maxTokens;
+    getConfig(): LLMServiceConfig {
+        const configuredMaxTokens = this.messageManager.getMaxTokens();
         return {
             provider: 'anthropic',
             model: this.model,

--- a/src/ai/llm/services/factory.ts
+++ b/src/ai/llm/services/factory.ts
@@ -10,6 +10,7 @@ import { OpenAIService } from './openai.js';
 import { AnthropicService } from './anthropic.js';
 import { LanguageModelV1 } from 'ai';
 import { EventEmitter } from 'events';
+import { LLMRouter } from '../types.js';
 
 /**
  * Extract and validate API key from config or environment variables
@@ -38,7 +39,7 @@ function extractApiKey(config: LLMConfig): string {
 /**
  * Create an LLM service instance based on the provided configuration
  */
-function _createLLMService(config: LLMConfig, clientManager: ClientManager, agentEventBus: EventEmitter): ILLMService {
+function _createInBuiltLLMService(config: LLMConfig, clientManager: ClientManager, agentEventBus: EventEmitter): ILLMService {
     // Extract and validate API key
     const apiKey = extractApiKey(config);
 
@@ -74,15 +75,19 @@ function _createVercelLLMService(
     return new VercelLLMService(clientManager, model, agentEventBus, config.systemPrompt);
 }
 
+/**
+ * Enum/type for LLM routing backend selection.
+ * 'vercel' = use Vercel LLM service, 'default' = use in-built LLM service
+ */
 export function createLLMService(
     config: LLMConfig,
-    vercel: boolean = false,
+    router: LLMRouter = 'vercel',
     clientManager: ClientManager,
     agentEventBus: EventEmitter
 ): ILLMService {
-    if (vercel) {
+    if (router === 'vercel') {
         return _createVercelLLMService(config, clientManager, agentEventBus);
     } else {
-        return _createLLMService(config, clientManager, agentEventBus);
+        return _createInBuiltLLMService(config, clientManager, agentEventBus);
     }
 }

--- a/src/ai/llm/services/factory.ts
+++ b/src/ai/llm/services/factory.ts
@@ -39,6 +39,14 @@ function extractApiKey(config: LLMConfig): string {
     return apiKey;
 }
 
+/**
+ * Create an instance of one of our in-built LLM services
+ * @param config LLM configuration from the config file
+ * @param clientManager Client manager instance
+ * @param agentEventBus Event emitter instance
+ * @param messageManager Message manager instance
+ * @returns ILLMService instance
+ */
 function _createInBuiltLLMService(
     config: LLMConfig,
     clientManager: ClientManager,

--- a/src/ai/llm/services/openai.ts
+++ b/src/ai/llm/services/openai.ts
@@ -43,30 +43,16 @@ export class OpenAIService implements ILLMService {
 
     constructor(
         clientManager: ClientManager,
-        systemPrompt: string,
-        apiKey: string,
+        openai: OpenAI,
         agentEventBus: EventEmitter,
-        model?: string
+        messageManager: MessageManager,
+        model: string
     ) {
-        this.model = model || 'gpt-4o-mini';
-        this.openai = new OpenAI({ apiKey });
+        this.model = model;
+        this.openai = openai;
         this.clientManager = clientManager;
-
-        // Initialize Formatter, Tokenizer, and get Max Tokens
-        const formatter = new OpenAIMessageFormatter();
-        const tokenizer = createTokenizer('openai', this.model);
-        const rawMaxTokens = getMaxTokens('openai', this.model);
-        const maxTokensWithMargin = Math.floor(rawMaxTokens * 0.9);
-
-        // Initialize MessageManager with OpenAIFormatter
-        this.messageManager = new MessageManager(
-            formatter,
-            systemPrompt || DETAILED_SYSTEM_PROMPT_TEMPLATE,
-            maxTokensWithMargin,
-            tokenizer
-        );
-
         this.eventEmitter = agentEventBus;
+        this.messageManager = messageManager;
     }
 
     getEventEmitter(): EventEmitter {

--- a/src/ai/llm/services/openai.ts
+++ b/src/ai/llm/services/openai.ts
@@ -1,35 +1,12 @@
 import OpenAI from 'openai';
 import { ClientManager } from '../../../client/manager.js';
-import { ILLMService } from './types.js';
+import { ILLMService, LLMServiceConfig } from './types.js';
 import { ToolSet } from '../../types.js';
 import { logger } from '../../../utils/logger.js';
 import { EventEmitter } from 'events';
 import { MessageManager } from '../messages/manager.js';
-import { OpenAIMessageFormatter } from '../messages/formatters/openai.js';
-import { createTokenizer } from '../tokenizer/factory.js';
 import { getMaxTokens } from '../tokenizer/utils.js';
-import { countMessagesTokens } from '../messages/utils.js';
-import { ITokenizer } from '../tokenizer/types.js';
 import { ImageData } from '../messages/types.js';
-
-// System prompt constants
-
-const DETAILED_SYSTEM_PROMPT_TEMPLATE = `You are an AI assistant with access to MCP tools. Your job is to help users accomplish their tasks by calling appropriate tools.
-
-
-## Follow these guidelines when using tools:
-1. Use tools whenever they can help complete the user's request. Do not ever say you don't have access to tools, read your tools completely and try to use them.
-2. You can call multiple tools in sequence to solve complex problems.
-3. After each tool returns a result, analyze the result carefully to determine next steps.
-4. If the result indicates you need additional information, call another tool to get that information.
-5. Continue this process until you have all the information needed to fulfill the user's request.
-6. Be concise in your responses, focusing on the task at hand.
-7. If a tool returns an error, try a different approach or ask the user for clarification.
-
-Remember: You can use multiple tool calls in a sequence to solve multi-step problems.
-
-## Available tools:
-TOOL_DESCRIPTIONS`;
 
 /**
  * OpenAI implementation of LLMService
@@ -180,8 +157,8 @@ export class OpenAIService implements ILLMService {
      * Get configuration information about the LLM service
      * @returns Configuration object with provider and model information
      */
-    getConfig(): { provider: string; model: string; [key: string]: any } {
-        const configuredMaxTokens = (this.messageManager as any).maxTokens;
+    getConfig(): LLMServiceConfig {
+        const configuredMaxTokens = this.messageManager.getMaxTokens();
         return {
             provider: 'openai',
             model: this.model,

--- a/src/ai/llm/services/openai.ts
+++ b/src/ai/llm/services/openai.ts
@@ -40,7 +40,6 @@ export class OpenAIService implements ILLMService {
     private clientManager: ClientManager;
     private messageManager: MessageManager;
     private eventEmitter: EventEmitter;
-    private tokenizer: ITokenizer;
 
     constructor(
         clientManager: ClientManager,
@@ -56,7 +55,6 @@ export class OpenAIService implements ILLMService {
         // Initialize Formatter, Tokenizer, and get Max Tokens
         const formatter = new OpenAIMessageFormatter();
         const tokenizer = createTokenizer('openai', this.model);
-        this.tokenizer = tokenizer;
         const rawMaxTokens = getMaxTokens('openai', this.model);
         const maxTokensWithMargin = Math.floor(rawMaxTokens * 0.9);
 
@@ -226,7 +224,7 @@ export class OpenAIService implements ILLMService {
                 );
 
                 // Directly count tokens and log
-                const currentTokens = countMessagesTokens([...this.messageManager.getHistory()], this.tokenizer);
+                const currentTokens = this.messageManager.getTokenCount();
                 logger.debug(`Estimated tokens being sent to OpenAI: ${currentTokens}`);
 
                 // Call OpenAI API

--- a/src/ai/llm/services/types.ts
+++ b/src/ai/llm/services/types.ts
@@ -28,8 +28,19 @@ export interface ILLMService {
     getAllTools(): Promise<ToolSet>;
 
     // Get configuration information about the LLM service
-    getConfig(): { provider: string; model: string } | { model: LanguageModelV1 };
+    getConfig(): LLMServiceConfig;
 
     // Get event emitter for subscribing to events
     getEventEmitter(): EventEmitter;
 }
+
+/**
+ * Configuration object returned by LLMService.getConfig()
+ */
+export type LLMServiceConfig = {
+    provider: string;
+    model: string | LanguageModelV1;
+    configuredMaxTokens?: number | null;
+    modelMaxTokens?: number | null;
+    [key: string]: any;
+};

--- a/src/ai/llm/services/vercel.ts
+++ b/src/ai/llm/services/vercel.ts
@@ -6,14 +6,9 @@ import { ToolSet } from '../../types.js';
 import { ToolSet as VercelToolSet, jsonSchema } from 'ai';
 import { EventEmitter } from 'events';
 import { MessageManager } from '../messages/manager.js';
-import { VercelMessageFormatter } from '../messages/formatters/vercel.js';
-import { createTokenizer } from '../tokenizer/factory.js';
-import { getMaxTokens } from '../tokenizer/utils.js';
 import { getProviderFromModel } from '../../utils.js';
-import { InternalMessage, ImageData } from '../messages/types.js';
-import { IMessageFormatter } from '../messages/formatters/types.js';
-import { countMessagesTokens } from '../messages/utils.js';
-import { ITokenizer } from '../tokenizer/types.js';
+import { getMaxTokens } from '../tokenizer/utils.js';
+import { ImageData } from '../messages/types.js';
 
 /**
  * Vercel implementation of LLMService
@@ -24,35 +19,20 @@ export class VercelLLMService implements ILLMService {
     private clientManager: ClientManager;
     private messageManager: MessageManager;
     private eventEmitter: EventEmitter;
-    private formatter: IMessageFormatter;
-    private tokenizer: ITokenizer;
 
-    constructor(clientManager: ClientManager, model: LanguageModelV1, agentEventBus: EventEmitter, systemPrompt: string) {
+    constructor(
+        clientManager: ClientManager,
+        model: LanguageModelV1,
+        agentEventBus: EventEmitter,
+        messageManager: MessageManager
+    ) {
         this.model = model;
         this.clientManager = clientManager;
         this.eventEmitter = agentEventBus;
-
-        // Detect provider, get tokenizer, and max tokens
         this.provider = getProviderFromModel(this.model.modelId);
-        const tokenizer = createTokenizer(this.provider, this.model.modelId);
-        this.tokenizer = tokenizer;
-        const rawMaxTokens = getMaxTokens(this.provider, this.model.modelId);
-        const maxTokensWithMargin = Math.floor(rawMaxTokens * 0.9);
-
-        // Use vercel formatter to match the message format vercel expects
-        const formatter = new VercelMessageFormatter();
-        this.formatter = formatter;
-
-        // Initialize MessageManager with Vercel formatter
-        this.messageManager = new MessageManager(
-            formatter,
-            systemPrompt,
-            maxTokensWithMargin,
-            tokenizer
-        );
-
+        this.messageManager = messageManager;
         logger.debug(
-            `[VercelLLMService] Initialized for model: ${this.model.modelId}, provider: ${this.provider}, formatter: VercelFormatter, maxTokens (adjusted): ${maxTokensWithMargin}`
+            `[VercelLLMService] Initialized for model: ${this.model.modelId}, provider: ${this.provider}, messageManager: ${this.messageManager}`
         );
     }
 
@@ -117,9 +97,7 @@ export class VercelLLMService implements ILLMService {
                 logger.silly(`Tools: ${JSON.stringify(formattedTools, null, 2)}`);
 
                 // Estimate tokens before sending (optional)
-                const currentTokens = countMessagesTokens([
-                    ...this.messageManager.getHistory(),
-                ], this.tokenizer);
+                const currentTokens = this.messageManager.getTokenCount();
                 logger.debug(
                     `Estimated tokens being sent to Vercel provider: ${currentTokens}`
                 );
@@ -197,11 +175,8 @@ export class VercelLLMService implements ILLMService {
             maxSteps: maxSteps,
         });
 
-        // Parse and append each new InternalMessage from the formatter
-        const newMsgs = this.formatter.parseResponse(response) || [];
-        for (const msg of newMsgs) {
-            this.messageManager.addMessage(msg);
-        }
+        // Parse and append each new InternalMessage from the formatter using MessageManager
+        this.messageManager.processLLMResponse(response);
         // Return the plain text of the response
         return response.text;
     }

--- a/src/ai/llm/services/vercel.ts
+++ b/src/ai/llm/services/vercel.ts
@@ -1,5 +1,5 @@
 import { ClientManager } from '../../../client/manager.js';
-import { ILLMService } from './types.js';
+import { ILLMService, LLMServiceConfig } from './types.js';
 import { logger } from '../../../utils/logger.js';
 import { streamText, generateText, CoreMessage, LanguageModelV1 } from 'ai';
 import { ToolSet } from '../../types.js';
@@ -293,7 +293,7 @@ export class VercelLLMService implements ILLMService {
      * Get configuration information about the LLM service
      * @returns Configuration object with provider and model information
      */
-    getConfig(): { provider: string; model: LanguageModelV1; [key: string]: any } {
+    getConfig(): LLMServiceConfig {
         const configuredMaxTokens = (this.messageManager as any).maxTokens;
         return {
             provider: `vercel:${this.provider}`,

--- a/src/ai/llm/types.ts
+++ b/src/ai/llm/types.ts
@@ -1,0 +1,5 @@
+/**
+ * LLMRouter defines the routing backend for LLM service instantiation.
+ * 'vercel' = use Vercel LLM service, 'default' = use in-built LLM service
+ */
+export type LLMRouter = 'vercel' | 'default'; 

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js';
 import { ToolProvider } from './types.js';
 import { ToolConfirmationProvider } from './tool-confirmation/types.js';
 import { CLIConfirmationProvider } from './tool-confirmation/cli-confirmation-provider.js';
+import { ToolSet } from '../ai/types.js';
 
 export class ClientManager {
     private clients: Map<string, ToolProvider> = new Map();
@@ -34,8 +35,8 @@ export class ClientManager {
      * Get all available tools from all connected clients
      * @returns Promise resolving to a map of tool names to tool definitions
      */
-    async getAllTools(): Promise<Record<string, any>> {
-        let allTools: Record<string, any> = {};
+    async getAllTools(): Promise<ToolSet> {
+        let allTools: ToolSet = {};
 
         // Clear existing maps to avoid stale entries
         this.toolToClientMap.clear();

--- a/src/client/tool-confirmation/factory.ts
+++ b/src/client/tool-confirmation/factory.ts
@@ -1,0 +1,32 @@
+/**
+ * ToolConfirmationProvider Factory
+ *
+ * Selects and instantiates the appropriate ToolConfirmationProvider implementation
+ * based on the application's run mode (cli, web, etc).
+ *
+ * Usage:
+ *   import { createToolConfirmationProvider } from './factory.js';
+ *   const provider = createToolConfirmationProvider(runMode);
+ *
+ * This centralizes provider selection logic, making it easy to extend and maintain.
+ */
+
+import { ToolConfirmationProvider } from './types.js';
+import { CLIConfirmationProvider } from './cli-confirmation-provider.js';
+import { NoOpConfirmationProvider } from './noop-confirmation-provider.js';
+// import { WebConfirmationProvider } from './web-confirmation-provider.js';
+// import { UIConfirmationProvider } from './ui-confirmation-provider.js';
+
+export function createToolConfirmationProvider(runMode: 'cli' | 'web'): ToolConfirmationProvider {
+  switch (runMode) {
+    case 'cli':
+      return new CLIConfirmationProvider();
+    case 'web':
+      // Fallback: No-op provider for now. Replace with real provider when available.
+      return new NoOpConfirmationProvider();
+    // case 'ui':
+    //   return new UIConfirmationProvider();
+    default:
+      throw new Error(`Unknown run mode for ToolConfirmationProvider: ${runMode}`);
+  }
+} 

--- a/src/client/tool-confirmation/factory.ts
+++ b/src/client/tool-confirmation/factory.ts
@@ -9,6 +9,7 @@
  *   const provider = createToolConfirmationProvider(runMode);
  *
  * This centralizes provider selection logic, making it easy to extend and maintain.
+ * TODO: implement web tool confirmation provider
  */
 
 import { ToolConfirmationProvider } from './types.js';
@@ -24,8 +25,6 @@ export function createToolConfirmationProvider(runMode: 'cli' | 'web'): ToolConf
     case 'web':
       // Fallback: No-op provider for now. Replace with real provider when available.
       return new NoOpConfirmationProvider();
-    // case 'ui':
-    //   return new UIConfirmationProvider();
     default:
       throw new Error(`Unknown run mode for ToolConfirmationProvider: ${runMode}`);
   }

--- a/src/client/tool-confirmation/noop-confirmation-provider.ts
+++ b/src/client/tool-confirmation/noop-confirmation-provider.ts
@@ -1,0 +1,18 @@
+/**
+ * NoOpConfirmationProvider
+ *
+ * A ToolConfirmationProvider implementation that always approves tool execution.
+ * Used as a fallback for environments (like 'web') where confirmation is not yet implemented.
+ *
+ * Uses InMemoryAllowedToolsProvider to satisfy the interface, but does not enforce any restrictions.
+ */
+import { ToolConfirmationProvider } from './types.js';
+import { InMemoryAllowedToolsProvider } from './allowed-tools-provider/in-memory.js';
+
+export class NoOpConfirmationProvider implements ToolConfirmationProvider {
+  public allowedToolsProvider = new InMemoryAllowedToolsProvider();
+
+  async requestConfirmation(/* details */): Promise<boolean> {
+    return true; // Always approve
+  }
+} 

--- a/src/utils/service-initializer.ts
+++ b/src/utils/service-initializer.ts
@@ -1,3 +1,30 @@
+/*
+ * Service Initializer: Centralized Wiring for Saiki Core Services
+ *
+ * This module is responsible for initializing and wiring together all core agent services (LLM, client manager, message manager, event bus, etc.)
+ * for the Saiki application. It provides a single entry point for constructing the service graph, ensuring consistent dependency injection
+ * and configuration across CLI, web, and test environments.
+ *
+ * **Configuration Pattern:**
+ * - The primary source of configuration is the config file (e.g., `saiki.yml`), which allows users to declaratively specify both high-level
+ *   and low-level service options (such as compression strategies for MessageManager, LLM provider/model, etc.).
+ * - For most use cases, the config file is sufficient and preferred, as it enables environment-specific, auditable, and user-friendly customization.
+ *
+ * **Override Pattern:**
+ * - For advanced, programmatic, or test scenarios, this initializer supports code-level overrides via the `InitializeServicesOptions` type.
+ * - These overrides are intended for swapping out top-level services (e.g., injecting a mock MessageManager or LLMService in tests), not for
+ *   overriding every internal dependency. This keeps the override API surface small, maintainable, and focused on real-world needs.
+ * - If deeper customization is required (e.g., a custom compression strategy for MessageManager in a test), construct the desired service
+ *   yourself and inject it via the appropriate top-level override (e.g., `messageManager`).
+ *
+ * **Best Practice:**
+ * - Use the config file for all user-facing and environment-specific configuration, including low-level service details.
+ * - Use code-level overrides only for top-level services and only when necessary (e.g., for testing, mocking, or advanced integration).
+ * - Do not expose every internal dependency as an override unless there is a strong, recurring need.
+ *
+ * This pattern ensures a clean, scalable, and maintainable architecture, balancing flexibility with simplicity.
+ */
+
 import { ClientManager } from '../client/manager.js';
 import { ILLMService } from '../ai/llm/services/types.js';
 import { AgentConfig } from '../config/types.js';
@@ -20,9 +47,19 @@ export type AgentServices = {
 
 /**
  * Options for overriding or injecting services/config at runtime.
- * This enables testability, context-specific tweaks, and advanced configuration.
- * - Use to override config fields, inject mocks, or pass runMode/context.
- * - All fields are optional; defaults to config file/env if not provided.
+ *
+ * **Design Rationale:**
+ * - The config file (e.g., `saiki.yml`) is the main source of truth for configuring both high-level and low-level service options.
+ *   This allows users and operators to declaratively tune the system without code changes.
+ * - The `InitializeServicesOptions` type is intended for advanced/test scenarios where you need to override top-level services
+ *   (such as injecting a mock MessageManager or LLMService). This keeps the override API surface small and focused.
+ * - For most use cases, do not expose every internal dependency here. If you need to customize internals (e.g., a custom compression strategy),
+ *   construct the service yourself and inject it as a top-level override.
+ *
+ * **Summary:**
+ * - Use config for normal operation and low-level tuning.
+ * - Use top-level service overrides for code/test/advanced scenarios.
+ * - This pattern is robust, scalable, and easy to maintain.
  */
 export type InitializeServicesOptions = {
     runMode?: 'cli' | 'web' | 'test'; // Context/mode override

--- a/src/utils/service-initializer.ts
+++ b/src/utils/service-initializer.ts
@@ -15,40 +15,65 @@ export type AgentServices = {
 };
 
 /**
- * Initialize services and clients based on the provided configuration
- * This is the central point for creating all services and dependencies
+ * Options for overriding or injecting services/config at runtime.
+ * This enables testability, context-specific tweaks, and advanced configuration.
+ * - Use to override config fields, inject mocks, or pass runMode/context.
+ * - All fields are optional; defaults to config file/env if not provided.
+ */
+export type InitializeServicesOptions = {
+    runMode?: 'cli' | 'web' | 'test'; // Context/mode override
+    clientManager?: ClientManager;     // Inject a custom or mock ClientManager
+    llmService?: ILLMService;         // Inject a custom or mock LLMService
+    agentEventBus?: EventEmitter;     // Inject a custom or mock EventEmitter
+    // Add more overrides as needed
+    // configOverride?: Partial<AgentConfig>; // (optional) for field-level config overrides
+};
+
+/**
+ * Initialize services and clients based on the provided configuration and optional overrides.
+ * This is the central point for creating all services and dependencies.
  * @param config Agent configuration including MCP servers and LLM settings
  * @param connectionMode Whether to enforce all connections must succeed ("strict") or allow partial success ("lenient")
+ * @param options Optional overrides for testability, context, or advanced configuration
  * @returns All the initialized services/dependencies necessary to run saiki
  */
 export async function initializeServices(
     config: AgentConfig,
-    connectionMode: 'strict' | 'lenient' = 'lenient'
+    connectionMode: 'strict' | 'lenient' = 'lenient',
+    options?: InitializeServicesOptions // <-- New parameter for overrides
 ): Promise<AgentServices> {
+    // TODO: Use options to override or inject services/config as needed
+    // Example: if (options?.clientManager) use it, else create a new one
+    // Example: if (options?.runMode) branch logic as needed
+
     /*
-     * 1. Create the shared event bus.
+     * 1. Create or use the shared event bus (allows override for tests/mocks)
      * This is a common resource used to communicate events between services.
      * It is used to notify subscribers when certain events occur.
      */
-    const agentEventBus = new EventEmitter();
+    const agentEventBus = options?.agentEventBus ?? new EventEmitter();
     logger.debug('Agent event bus initialized');
 
     /**
-     * 2. Initialize client manager with the mcp server configs and connection mode
+     * 2. Create the client manager and initialize it mcp server configs and connection mode (allows override for tests/mocks)
      * This is used to manage all the connections to MCP servers.
      */
-    const clientManager = new ClientManager();
+    const clientManager = options?.clientManager ?? new ClientManager();
     await clientManager.initializeFromConfig(config.mcpServers, connectionMode);
     logger.debug('Client manager and MCP servers initialized');
 
     /**
-     * 3. Initialize the LLMService
+     * 3. Initialize or use the LLMService (allows override for tests/mocks)
      * This is used to orchestrate the LLM to generate messages and handle looping logic
      */
     // Change vercel to false to use in-built LLM services. TODO: Make this configurable
     const vercel = true;
-    const llmService = createLLMService(config.llm, vercel, clientManager, agentEventBus);
-    logger.debug('LLM service initialized');
+    const llmService = options?.llmService ?? createLLMService(config.llm, vercel, clientManager, agentEventBus);
+    if (!options?.llmService) {
+        logger.debug('LLM service initialized');
+    } else {
+        logger.debug('LLM service provided via options override');
+    }
 
     return { clientManager, llmService, agentEventBus };
 }


### PR DESCRIPTION
This will help with #67 . This follows best practices of dependency injection - inject all dependencies from the top and helps us achieve the following goals:

1. Easier configurablity - now that services are being initialized at the top, it's easy to wire options/configs from `saiki.yml` to decide how to initialize them and give maximum control to users.
2. More testable and modular - dependency injection allows easily substituting mock classes instead of real ones wherever needed.
3. Direct access to services for web UI/CLI interfaces - having services at the top also makes it much easier to add features for our web UI and CLI to make it more useful

### High level Changes:
1. Have all services and dependencies initialized at the top level - `service-initializer.ts`
4. Allow us to configure most features via config file `saiki.yml`
5. Have a way to enable internal overrides through code - this is useful for testing and any custom use-cases.
6. Wherever we needed a way to control what specific implementation of an interface is created, we have added a `factory.ts` file in the specific folder with the required arguments.


On 1 - we pass the `AgentConfig` into `service-initializer.ts`. We can update the logic of this file to read the appropriate sub-configs from `AgentConfig` and use that to initialize services in a custom manner

On 2 - created `InitializeServiceOptions` - which goes into `service-initializer.ts`. This allows us to have code-level overrides for top level services like LLMService, MessageManager, etc. 

Priority: code override > config file > internal defaults


### Tenets
1. Allow all features to be configurable via either config file or code-level override
2. Allow low-level classes/services (Formatters/tokenizers/etc.) to be configurable via config file
3. Only keep high level classes/services (LLMService, MessageManager, etc.) to be configurable via code-override - this is to avoid bloating `InitializeServiceOptions`

This enables us to use config file to support most features and low level customization, but for advanced code level requirements (like custom testing and mocking), there is still flexibility to inject top level services like `LLMService`, `ClientManager`, `MessageManager`, etc along with their low level dependencies.


### Notes:

1. As of now, we haven't updated our `AgentConfig` yet to allow these things to be customizable via config file - this will come later.
2. We also haven't fully exposed low level classes like `Formatters`, `Tokenizers`, `ToolConfirmationProvider` to be driven via config. This hasn't been done because these are mostly internal implementations. If we do need to make these also configurable, it will be much easier now that initialization is closer to the top. (just add a new section in `AgentConfig`, and update the corresponding `factory` or `initializeServices` logic)