### PR TITLE
feat: dynamic logging level control during runtime

### DIFF
--- a/app/cli/cli.ts
+++ b/app/cli/cli.ts
@@ -85,7 +85,6 @@ export async function runAiCli(
         function handleCliCommand(input: string): boolean {
             const lowerInput = input.toLowerCase().trim();
 
-            // Existing commands
             if (lowerInput === 'exit' || lowerInput === 'quit') {
                 logger.warn('Exiting AI CLI. Goodbye!');
                 rl.close();
@@ -98,25 +97,10 @@ export async function runAiCli(
                 return true;
             }
 
-            // New log level commands
             if (validLogLevels.includes(lowerInput)) {
                 logger.setLevel(lowerInput);
                 return true;
             }
-
-            /*
-            if (lowerInput.startsWith('loglevel ')) {
-                const level = lowerInput.split(' ')[1];
-                if (validLogLevels.includes(level)) {
-                    logger.setLevel(level);
-                } else {
-                    logger.warn(
-                        `Invalid log level. Valid levels are: ${validLogLevels.join(', ')}`
-                    );
-                }
-                return true;
-            }
-            */
 
             if (lowerInput === 'currentloglevel') {
                 logger.info(`Current log level: ${logger.getLevel()}`);
@@ -132,16 +116,13 @@ export async function runAiCli(
         }
 
         function showHelp() {
-            logger.info(`
-        Available commands:
-          exit/quit - Exit the CLI
-          clear - Clear conversation history
-          help - Show this help message
-          currentloglevel - Show current logging level
-          debug|verbose|info|warn|error|silly - Set logging level directly
-          
-          Available log levels: ${validLogLevels.join(', ')}
-          `);
+            logger.info(`Available commands:
+                exit/quit - Exit the CLI
+                clear - Clear conversation history
+                help - Show this help message
+                currentloglevel - Show current logging level
+                ${validLogLevels.join('|')} - Set logging level directly
+                `);
         }
 
         try {

--- a/app/cli/cli.ts
+++ b/app/cli/cli.ts
@@ -5,12 +5,19 @@ import { logger } from '../../src/utils/logger.js'; // Adjusted path
 import { ILLMService } from '../../src/ai/llm/services/types.js'; // Adjusted path
 import { CLISubscriber } from './cli-subscriber.js'; // Now points to the new location
 import { EventEmitter } from 'events';
+
+const validLogLevels = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
+
 /**
  * Run the AI CLI with the given LLM service
  * @param clientManager Client manager with registered tool providers
  * @param llmService LLM service implementation
  */
-export async function runAiCli(clientManager: ClientManager, llmService: ILLMService, agentEventBus: EventEmitter) {
+export async function runAiCli(
+    clientManager: ClientManager,
+    llmService: ILLMService,
+    agentEventBus: EventEmitter
+) {
     // Get model and provider info directly from the LLM service
     logger.info(
         `Using model config: ${JSON.stringify(llmService.getConfig(), null, 2)}`,
@@ -35,7 +42,10 @@ export async function runAiCli(clientManager: ClientManager, llmService: ILLMSer
         agentEventBus.on('llmservice:toolResult', cliSubscriber.onToolResult.bind(cliSubscriber));
         agentEventBus.on('llmservice:response', cliSubscriber.onResponse.bind(cliSubscriber));
         agentEventBus.on('llmservice:error', cliSubscriber.onError.bind(cliSubscriber));
-        agentEventBus.on('llmservice:conversationReset', cliSubscriber.onConversationReset.bind(cliSubscriber));
+        agentEventBus.on(
+            'llmservice:conversationReset',
+            cliSubscriber.onConversationReset.bind(cliSubscriber)
+        );
 
         // Get available tools from all connected servers
         logger.info('Loading available tools...');
@@ -72,20 +82,73 @@ export async function runAiCli(clientManager: ClientManager, llmService: ILLMSer
             });
         };
 
+        function handleCliCommand(input: string): boolean {
+            const lowerInput = input.toLowerCase().trim();
+
+            // Existing commands
+            if (lowerInput === 'exit' || lowerInput === 'quit') {
+                logger.warn('Exiting AI CLI. Goodbye!');
+                rl.close();
+                process.exit(0);
+            }
+
+            if (lowerInput === 'clear') {
+                llmService.resetConversation();
+                logger.info('Conversation history cleared.');
+                return true;
+            }
+
+            // New log level commands
+            if (validLogLevels.includes(lowerInput)) {
+                logger.setLevel(lowerInput);
+                return true;
+            }
+
+            /*
+            if (lowerInput.startsWith('loglevel ')) {
+                const level = lowerInput.split(' ')[1];
+                if (validLogLevels.includes(level)) {
+                    logger.setLevel(level);
+                } else {
+                    logger.warn(
+                        `Invalid log level. Valid levels are: ${validLogLevels.join(', ')}`
+                    );
+                }
+                return true;
+            }
+            */
+
+            if (lowerInput === 'currentloglevel') {
+                logger.info(`Current log level: ${logger.getLevel()}`);
+                return true;
+            }
+
+            if (lowerInput === 'help') {
+                showHelp();
+                return true;
+            }
+
+            return false;
+        }
+
+        function showHelp() {
+            logger.info(`
+        Available commands:
+          exit/quit - Exit the CLI
+          clear - Clear conversation history
+          help - Show this help message
+          currentloglevel - Show current logging level
+          debug|verbose|info|warn|error|silly - Set logging level directly
+          
+          Available log levels: ${validLogLevels.join(', ')}
+          `);
+        }
+
         try {
             while (true) {
                 const userInput = await promptUser();
 
-                if (userInput.toLowerCase() === 'exit' || userInput.toLowerCase() === 'quit') {
-                    logger.warn('Exiting AI CLI. Goodbye!');
-                    rl.close();
-                    // Use process.exit(0) for a clean exit in CLI mode
-                    process.exit(0);
-                }
-
-                if (userInput.toLowerCase() === 'clear') {
-                    llmService.resetConversation();
-                    logger.info('Conversation history cleared.');
+                if (handleCliCommand(userInput)) {
                     continue;
                 }
 

--- a/app/cli/cli.ts
+++ b/app/cli/cli.ts
@@ -7,6 +7,13 @@ import { CLISubscriber } from './cli-subscriber.js'; // Now points to the new lo
 import { EventEmitter } from 'events';
 
 const validLogLevels = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
+const HELP_MESSAGE = `Available commands:
+exit/quit - Exit the CLI
+clear - Clear conversation history
+help - Show this help message
+currentloglevel - Show current logging level
+${validLogLevels.join('|')} - Set logging level directly
+`;
 
 /**
  * Run the AI CLI with the given LLM service
@@ -116,13 +123,7 @@ export async function runAiCli(
         }
 
         function showHelp() {
-            logger.info(`Available commands:
-                exit/quit - Exit the CLI
-                clear - Clear conversation history
-                help - Show this help message
-                currentloglevel - Show current logging level
-                ${validLogLevels.join('|')} - Set logging level directly
-                `);
+            logger.info(HELP_MESSAGE);
         }
 
         try {


### PR DESCRIPTION
This PR implements the feature, allowing users to change the logging level dynamically during CLI runtime.

Used existing `setLevel()` and `getLevel()` methods in `logger.ts`

Supports all log levels: `error, warn, info, http, verbose, debug, silly`

Resolves #30 

### New CLI Commands
Direct level commands
- debug|verbose|info|warn|error|silly

Check current level
- currentloglevel

Video: 


https://github.com/user-attachments/assets/d629718e-a0b7-4f32-901f-cbcfc27b867c


