### PR TITLE
Add auto-publish github workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        continue-on-error: true  # Remove or set to false if build is required
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 


### PR DESCRIPTION
Note: merging to test it out

Steps to publish a workflow:

1. update the version of saiki locally

For a PATCH release (e.g., 1.2.3 → 1.2.4)
`npm version patch`

For a MINOR release (e.g., 1.2.3 → 1.3.0)
`npm version minor`

For a MAJOR release (e.g., 1.2.3 → 2.0.0)
`npm version major`
this creates a new commit with a git tag

2. push the commit

`git push origin main --follow-tags`

3. github action automatically pushes to npm

the workflow in `.github/workflows/publish.yml` triggers based on the git tags and publishes to npm

This gives us control of when to publish a new version but simplifies the automation and history