### PR TITLE
Add prompt contributors for customizable system prompts

### DIFF
--- a/src/ai/llm/messages/factory.ts
+++ b/src/ai/llm/messages/factory.ts
@@ -8,6 +8,7 @@ import { LLMConfig } from '../../../config/types.js';
 import { LLMRouter } from '../types.js';
 import { IMessageFormatter } from './formatters/types.js';
 import { ITokenizer } from '../tokenizer/types.js';
+import { SystemPromptContributor } from '../../systemPrompt/types.js';
 
 /**
  * Factory function to create a MessageManager instance with the correct formatter, tokenizer, and maxTokens
@@ -15,12 +16,14 @@ import { ITokenizer } from '../tokenizer/types.js';
  *
  * @param config LLMConfig object containing provider, model, systemPrompt, etc.
  * @param router LLMRouter flag ('vercel', 'default', etc.)
+ * @param contributors SystemPromptContributor[]
  * @returns MessageManager instance
  * TODO: Make compression strategy also configurable
  */
 export function createMessageManager(
     config: LLMConfig,
-    router: LLMRouter = 'vercel'
+    router: LLMRouter = 'vercel',
+    contributors: SystemPromptContributor[]
 ): MessageManager {
     let formatter: IMessageFormatter;
     let tokenizer: ITokenizer;
@@ -50,7 +53,7 @@ export function createMessageManager(
 
     return new MessageManager(
         formatter,
-        config.systemPrompt,
+        contributors,
         maxTokens,
         tokenizer
     );

--- a/src/ai/llm/messages/formatters/anthropic.ts
+++ b/src/ai/llm/messages/formatters/anthropic.ts
@@ -167,7 +167,7 @@ export class AnthropicMessageFormatter implements IMessageFormatter {
      * @param systemPrompt The system prompt to format
      * @returns The system prompt without any modification
      */
-    getSystemPrompt(systemPrompt: string | null): string | null {
+    formatSystemPrompt(systemPrompt: string | null): string | null {
         // Anthropic uses system prompt as a separate parameter, no need for any formatting
         return systemPrompt;
     }

--- a/src/ai/llm/messages/formatters/openai.ts
+++ b/src/ai/llm/messages/formatters/openai.ts
@@ -85,7 +85,7 @@ export class OpenAIMessageFormatter implements IMessageFormatter {
      *
      * @returns null as OpenAI doesn't need a separate system prompt
      */
-    getSystemPrompt(): null {
+    formatSystemPrompt(): null {
         return null;
     }
 

--- a/src/ai/llm/messages/formatters/types.ts
+++ b/src/ai/llm/messages/formatters/types.ts
@@ -30,5 +30,5 @@ export interface IMessageFormatter {
      * @param systemPrompt The system prompt to format
      * @returns The formatted system prompt or null/undefined if not needed
      */
-    getSystemPrompt?(systemPrompt: string | null): string | null | undefined;
+    formatSystemPrompt?(systemPrompt: string | null): string | null | undefined;
 }

--- a/src/ai/llm/messages/formatters/vercel.ts
+++ b/src/ai/llm/messages/formatters/vercel.ts
@@ -66,7 +66,7 @@ export class VercelMessageFormatter implements IMessageFormatter {
      *
      * @returns null as Vercel doesn't need a separate system prompt
      */
-    getSystemPrompt(): null {
+    formatSystemPrompt(): null {
         return null;
     }
 

--- a/src/ai/llm/messages/manager.ts
+++ b/src/ai/llm/messages/manager.ts
@@ -100,12 +100,14 @@ export class MessageManager {
      * This is a placeholder; actual implementation should run getContent on each contributor with the correct context.
      */
     async getSystemPrompt(context: DynamicContributorContext): Promise<string> {
-        // If only one static contributor (legacy), return its content
-        if (this.systemPromptContributors.length === 1 && 'getContent' in this.systemPromptContributors[0]) {
-            return await this.systemPromptContributors[0].getContent(context);
-        }
-        // Otherwise, assemble from all contributors
-        const parts = await Promise.all(this.systemPromptContributors.map(c => c.getContent(context)));
+        // Assemble the system prompt from all contributors
+        const parts = await Promise.all(
+            this.systemPromptContributors.map(async c => {
+                const content = await c.getContent(context);
+                logger.debug(`[SystemPrompt] Contributor '${c.id}' (priority: ${c.priority}):\n${content}`);
+                return content;
+            })
+        );
         return parts.join('\n');
     }
 

--- a/src/ai/llm/messages/utils.ts
+++ b/src/ai/llm/messages/utils.ts
@@ -2,7 +2,7 @@ import { InternalMessage } from './types.js';
 import { ITokenizer } from '../tokenizer/types.js';
 
 // Approximation for message format overhead
-export const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
+const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
 
 /**
  * Counts the total tokens in an array of InternalMessages using a provided tokenizer.

--- a/src/ai/llm/messages/utils.ts
+++ b/src/ai/llm/messages/utils.ts
@@ -2,7 +2,7 @@ import { InternalMessage } from './types.js';
 import { ITokenizer } from '../tokenizer/types.js';
 
 // Approximation for message format overhead
-const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
+export const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
 
 /**
  * Counts the total tokens in an array of InternalMessages using a provided tokenizer.

--- a/src/ai/llm/services/anthropic.ts
+++ b/src/ai/llm/services/anthropic.ts
@@ -67,16 +67,17 @@ export class AnthropicService implements ILLMService {
                 iterationCount++;
                 logger.debug(`Iteration ${iterationCount}`);
 
-                // Get formatted messages from message manager
-                const messages = this.messageManager.getFormattedMessages();
-                const systemPrompt = this.messageManager.getFormattedSystemPrompt();
+                // Compute the system prompt and pass it to message manager to avoid duplicate computation
+                const context = { clientManager: this.clientManager };
+                const formattedSystemPrompt = await this.messageManager.getFormattedSystemPrompt(context);
+                const messages = await this.messageManager.getFormattedMessages(context, formattedSystemPrompt);
 
                 logger.debug(`Messages: ${JSON.stringify(messages, null, 2)}`);
 
                 const response = await this.anthropic.messages.create({
                     model: this.model,
                     messages: messages,
-                    system: systemPrompt,
+                    system: formattedSystemPrompt,
                     tools: formattedTools,
                     max_tokens: 4096,
                 });

--- a/src/ai/llm/services/openai.ts
+++ b/src/ai/llm/services/openai.ts
@@ -180,7 +180,7 @@ export class OpenAIService implements ILLMService {
 
             try {
                 // Get formatted messages from message manager
-                const formattedMessages = this.messageManager.getFormattedMessages();
+                const formattedMessages = await this.messageManager.getFormattedMessages({ clientManager: this.clientManager });
 
                 logger.silly(
                     `Message history (potentially compressed) in getAIResponseWithRetries: ${JSON.stringify(formattedMessages, null, 2)}`

--- a/src/ai/llm/services/vercel.ts
+++ b/src/ai/llm/services/vercel.ts
@@ -89,7 +89,7 @@ export class VercelLLMService implements ILLMService {
                 logger.debug(`Iteration ${iterationCount}`);
 
                 // Get formatted messages from message manager
-                const formattedMessages = this.messageManager.getFormattedMessages();
+                const formattedMessages = await this.messageManager.getFormattedMessages({ clientManager: this.clientManager });
 
                 logger.debug(
                     `Messages (potentially compressed): ${JSON.stringify(formattedMessages, null, 2)}`

--- a/src/ai/systemPrompt/contributors.ts
+++ b/src/ai/systemPrompt/contributors.ts
@@ -1,0 +1,25 @@
+import { SystemPromptContributor, DynamicContributorContext } from './types.js';
+
+export class StaticContributor implements SystemPromptContributor {
+  constructor(
+    public id: string,
+    public priority: number,
+    private content: string
+  ) {}
+
+  async getContent(_context: DynamicContributorContext): Promise<string> {
+    return this.content;
+  }
+}
+
+export class DynamicContributor implements SystemPromptContributor {
+  constructor(
+    public id: string,
+    public priority: number,
+    private handler: (context: DynamicContributorContext) => Promise<string>
+  ) {}
+
+  async getContent(context: DynamicContributorContext): Promise<string> {
+    return this.handler(context);
+  }
+} 

--- a/src/ai/systemPrompt/in-built-prompts.ts
+++ b/src/ai/systemPrompt/in-built-prompts.ts
@@ -1,0 +1,20 @@
+import { DynamicContributorContext } from './types.js';
+
+export async function getCurrentDateTime(_context: DynamicContributorContext): Promise<string> {
+  return `Current date and time: ${new Date().toISOString()}`;
+}
+
+export async function getMemorySummary(_context: DynamicContributorContext): Promise<string> {
+  // Placeholder for actual memory logic
+  return 'Memory summary: [not implemented]';
+}
+
+export async function getUserInstructions(_context: DynamicContributorContext): Promise<string> {
+  // Placeholder for user instructions logic
+  return '';
+}
+
+export async function getToolListing(_context: DynamicContributorContext): Promise<string> {
+  // Placeholder for tool listing logic
+  return 'Available tools: ...';
+} 

--- a/src/ai/systemPrompt/in-built-prompts.ts
+++ b/src/ai/systemPrompt/in-built-prompts.ts
@@ -8,13 +8,3 @@ export async function getMemorySummary(_context: DynamicContributorContext): Pro
   // Placeholder for actual memory logic
   return 'Memory summary: [not implemented]';
 }
-
-export async function getUserInstructions(_context: DynamicContributorContext): Promise<string> {
-  // Placeholder for user instructions logic
-  return '';
-}
-
-export async function getToolListing(_context: DynamicContributorContext): Promise<string> {
-  // Placeholder for tool listing logic
-  return 'Available tools: ...';
-} 

--- a/src/ai/systemPrompt/in-built-prompts.ts
+++ b/src/ai/systemPrompt/in-built-prompts.ts
@@ -1,10 +1,24 @@
 import { DynamicContributorContext } from './types.js';
 
+/**
+ * Dynamic Prompt Generators
+ *
+ * This module contains functions for generating dynamic system prompts for the AI agent.
+ * Each function should return a string (or Promise<string>) representing a prompt, possibly using the provided context.
+ *
+ * ---
+ * Guidelines for Adding Prompt Functions:
+ * - Place all dynamic prompt-generating functions in this file.
+ * - Also update the `registry.ts` file to register the new function.
+ * - Use XML tags to indicate the start and end of the dynamic prompt - they are known to improve performance
+ * - Each function should be named clearly to reflect its purpose (e.g., getCurrentDateTime, getMemorySummary).
+ */
+
 export async function getCurrentDateTime(_context: DynamicContributorContext): Promise<string> {
-  return `Current date and time: ${new Date().toISOString()}`;
+  return `<dateTime>Current date and time: ${new Date().toISOString()}</dateTime>`;
 }
 
 export async function getMemorySummary(_context: DynamicContributorContext): Promise<string> {
   // Placeholder for actual memory logic
-  return 'Memory summary: [not implemented]';
+  return '<memorySummary>Memory summary: [not implemented]</memorySummary>';
 }

--- a/src/ai/systemPrompt/loader.ts
+++ b/src/ai/systemPrompt/loader.ts
@@ -1,0 +1,42 @@
+import { ContributorConfig, SystemPromptConfig } from '../../config/types.js';
+import { SystemPromptContributor } from './types.js';
+import { StaticContributor, DynamicContributor } from './contributors.js';
+import { getSourceHandler } from './registry.js';
+
+export function loadContributors(
+  systemPromptConfig: string | SystemPromptConfig
+): SystemPromptContributor[] {
+  const defaultContributors: ContributorConfig[] = [
+    { id: 'dateTime', type: 'dynamic', priority: 10, source: 'dateTime', enabled: true },
+  ];
+
+  let contributors: ContributorConfig[] = [];
+
+  if (typeof systemPromptConfig === 'string') {
+    contributors = [
+      { id: 'legacyPrompt', type: 'static', priority: 0, content: systemPromptConfig, enabled: true }
+    ];
+  } else {
+    contributors = [...defaultContributors];
+    for (const userC of systemPromptConfig.contributors) {
+      const idx = contributors.findIndex(c => c.id === userC.id);
+      if (idx !== -1) contributors[idx] = userC;
+      else contributors.push(userC);
+    }
+    contributors = contributors.filter(c => c.enabled !== false);
+  }
+
+  const result: SystemPromptContributor[] = contributors.map(c => {
+    if (c.type === 'static') {
+      if (!c.content) throw new Error(`Static contributor "${c.id}" missing content`);
+      return new StaticContributor(c.id, c.priority, c.content);
+    } else if (c.type === 'dynamic' && c.source) {
+      const handler = getSourceHandler(c.source);
+      if (!handler) throw new Error(`No handler for dynamic contributor source: ${c.source}`);
+      return new DynamicContributor(c.id, c.priority, handler);
+    }
+    throw new Error(`Invalid contributor config: ${JSON.stringify(c)}`);
+  });
+
+  return result.sort((a, b) => a.priority - b.priority);
+} 

--- a/src/ai/systemPrompt/loader.ts
+++ b/src/ai/systemPrompt/loader.ts
@@ -37,6 +37,6 @@ export function loadContributors(
     }
     throw new Error(`Invalid contributor config: ${JSON.stringify(c)}`);
   });
-
+  // Lower priority number first, so 0 is highest priority
   return result.sort((a, b) => a.priority - b.priority);
 } 

--- a/src/ai/systemPrompt/registry.ts
+++ b/src/ai/systemPrompt/registry.ts
@@ -1,13 +1,15 @@
 import * as handlers from './in-built-prompts.js';
 import { DynamicContributorContext } from './types.js';
 
+/**
+ * This file contains the registry of all the source handlers for dynamic contributors for the system prompt.
+ */
 export type SourceHandler = (context: DynamicContributorContext) => Promise<string>;
 
 export const sourceHandlerRegistry: Record<string, SourceHandler> = {
-  dateTime: handlers.getCurrentDateTime,
-  memorySummary: handlers.getMemorySummary,
-  userInstructions: handlers.getUserInstructions,
-  toolListing: handlers.getToolListing,
+    dateTime: handlers.getCurrentDateTime,
+    memorySummary: handlers.getMemorySummary,
+    // Add other handlers here
 };
 
 export function getSourceHandler(source: string): SourceHandler | undefined {

--- a/src/ai/systemPrompt/registry.ts
+++ b/src/ai/systemPrompt/registry.ts
@@ -1,0 +1,15 @@
+import * as handlers from './in-built-prompts.js';
+import { DynamicContributorContext } from './types.js';
+
+export type SourceHandler = (context: DynamicContributorContext) => Promise<string>;
+
+export const sourceHandlerRegistry: Record<string, SourceHandler> = {
+  dateTime: handlers.getCurrentDateTime,
+  memorySummary: handlers.getMemorySummary,
+  userInstructions: handlers.getUserInstructions,
+  toolListing: handlers.getToolListing,
+};
+
+export function getSourceHandler(source: string): SourceHandler | undefined {
+  return sourceHandlerRegistry[source];
+} 

--- a/src/ai/systemPrompt/types.ts
+++ b/src/ai/systemPrompt/types.ts
@@ -1,0 +1,14 @@
+import { AgentConfig } from '../../config/types.js';
+import { ClientManager } from '../../client/manager.js';
+
+// Context passed to dynamic contributors
+export interface DynamicContributorContext {
+  clientManager: ClientManager;
+}
+
+// Interface for all system prompt contributors
+export interface SystemPromptContributor {
+  id: string;
+  priority: number;
+  getContent(context: DynamicContributorContext): Promise<string>;
+} 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -40,10 +40,23 @@ export type ServerConfigs = Record<string, McpServerConfig>;
 /**
  * LLM configuration type
  */
+export interface ContributorConfig {
+  id: string;
+  type: 'static' | 'dynamic';
+  priority: number;
+  enabled?: boolean;
+  content?: string; // for static
+  source?: string;  // for dynamic
+}
+
+export interface SystemPromptConfig {
+  contributors: ContributorConfig[];
+}
+
 export type LLMConfig = {
     provider: string;
     model: string;
-    systemPrompt: string;
+    systemPrompt: string | SystemPromptConfig;
     apiKey?: string;
     providerOptions?: Record<string, any>;
 };

--- a/src/utils/service-initializer.ts
+++ b/src/utils/service-initializer.ts
@@ -35,6 +35,7 @@ import { LLMRouter } from '../ai/llm/types.js';
 import { MessageManager } from '../ai/llm/messages/manager.js';
 import { createMessageManager } from '../ai/llm/messages/factory.js';
 import { createToolConfirmationProvider } from '../client/tool-confirmation/factory.js';
+import { loadContributors } from '../ai/systemPrompt/loader.js';
 
 /**
  * Type for the core agent services returned by initializeServices
@@ -112,7 +113,8 @@ export async function initializeServices(
      *    - 'vercel' = Vercel-style message formatting (default), 'default' = in-built provider-specific formatting
      */
     const router: LLMRouter = options?.llmRouter ?? 'vercel';
-    const messageManager = options?.messageManager ?? createMessageManager(config.llm, router);
+    const contributors = loadContributors(config.llm.systemPrompt);
+    const messageManager = options?.messageManager ?? createMessageManager(config.llm, router, contributors);
 
     /**
      * 4. Initialize or use the LLMService (allows override for tests/mocks)


### PR DESCRIPTION
formalizing https://github.com/truffle-ai/saiki/pull/62 after lot of rebasing and other PRs

****
### Overview 
This PR introduces a new, extensible system for building system prompts in Saiki by adding the concept of "prompt contributors." Instead of a single static system prompt string, the LLM configuration can now specify a list of contributors—each of which can be static (fixed text) or dynamic (generated at runtime, e.g., current date/time, memory summary, tool listing, etc.). The system prompt is then assembled from all enabled contributors, ordered by priority.

Key changes:

 - Adds new types and loader logic for SystemPromptContributor (static and dynamic) and their configuration.
Refactors the MessageManager and related LLM service code to use an array of contributors instead of a single system prompt string.
 - Introduces built-in dynamic contributors (date/time, memory summary, user instructions, tool listing) and a registry for mapping contributor sources to handler functions.
- Updates the LLM config type to allow either a string or a structured SystemPromptConfig with contributors. [string is for backward compatibility/simple use-cases]
- Refactors message formatting and initialization logic to support the new contributor-based system prompt assembly.

### Summary:
- This enables highly customizable, composable, and context-aware system prompts for LLMs in Saiki, paving the way for more dynamic agent behavior and easier prompt management.

Sample new config file using contributors:

```
# describes the mcp servers to use
mcpServers:
  filesystem:
    type: stdio
    command: npx
    args:
      - -y
      - "@modelcontextprotocol/server-filesystem"
      - .
  puppeteer:
    type: stdio
    command: node
    args:
      - dist/src/servers/puppeteerServer.js

# # describes the llm configuration
llm:
  provider: openai
  model: gpt-4.1-mini
  # you can update the system prompt to change the behavior of the llm
  systemPrompt:
    contributors:
      - id: primary
        type: static
        priority: 0
        content: |
          You are Saiki, a helpful AI assistant with access to tools.
          Use these tools when appropriate to answer user queries.
          You can use multiple tools in sequence to solve complex problems.
          After each tool result, determine if you need more information or can provide a final answer.
      - id: dateTime
        type: dynamic
        priority: 10
        source: dateTime
        enabled: true
      - id: memory
        type: dynamic
        priority: 20
        source: memorySummary
        enabled: false
  apiKey: $OPENAI_API_KEY
```
`id` is a name to identify the prompt contributor - any valid string works
`type` indicates if the prompt contributor is `static` or `dynamic`
`priority` denotes the order in which the prompts are added into the system prompt (lower priority = first)
`enabled` is a helper flag to turn on/off a prompt contributor without deleting it
`source` is for `dynamic` prompt contributors and represents the function that is used to dynamically generate the prompt. it needs to match an exact entry in `in-built-prompts.ts` to avoid runtime errors. 
`content` is for `static` prompt contributors and is the static content that goes into the system prompt

