### PR TITLE
Add PromptManager class

### DIFF
--- a/app/cli/cli.ts
+++ b/app/cli/cli.ts
@@ -42,16 +42,7 @@ async function _initCli(
     // Set up event management
     logger.info('Setting up CLI event subscriptions...');
     const cliSubscriber = new CLISubscriber();
-    agentEventBus.on('llmservice:thinking', cliSubscriber.onThinking.bind(cliSubscriber));
-    agentEventBus.on('llmservice:chunk', cliSubscriber.onChunk.bind(cliSubscriber));
-    agentEventBus.on('llmservice:toolCall', cliSubscriber.onToolCall.bind(cliSubscriber));
-    agentEventBus.on('llmservice:toolResult', cliSubscriber.onToolResult.bind(cliSubscriber));
-    agentEventBus.on('llmservice:response', cliSubscriber.onResponse.bind(cliSubscriber));
-    agentEventBus.on('llmservice:error', cliSubscriber.onError.bind(cliSubscriber));
-    agentEventBus.on(
-        'llmservice:conversationReset',
-        cliSubscriber.onConversationReset.bind(cliSubscriber)
-    );
+    cliSubscriber.subscribe(agentEventBus);
 
     // Load available tools
     logger.info('Loading available tools...');

--- a/src/ai/llm/messages/factory.ts
+++ b/src/ai/llm/messages/factory.ts
@@ -3,9 +3,7 @@ import { createMessageFormatter } from './formatters/factory.js';
 import { createTokenizer } from '../tokenizer/factory.js';
 import { LLMConfig } from '../../../config/types.js';
 import { LLMRouter } from '../types.js';
-import { IMessageFormatter } from './formatters/types.js';
-import { ITokenizer } from '../tokenizer/types.js';
-import { SystemPromptContributor } from '../../systemPrompt/types.js';
+import { PromptManager } from '../../systemPrompt/manager.js';
 import { logger } from '../../../utils/logger.js';
 import { getMaxTokensForModel } from '../registry.js';
 
@@ -15,14 +13,14 @@ import { getMaxTokensForModel } from '../registry.js';
  *
  * @param config LLMConfig object containing provider, model, systemPrompt, etc.
  * @param router LLMRouter flag
- * @param contributors SystemPromptContributor[]
+ * @param promptManager PromptManager instance
  * @returns MessageManager instance
  * TODO: Make compression strategy also configurable
  */
 export function createMessageManager(
     config: LLMConfig,
     router: LLMRouter = 'vercel',
-    contributors: SystemPromptContributor[]
+    promptManager: PromptManager
 ): MessageManager {
     const provider = config.provider.toLowerCase();
     const model = config.model.toLowerCase();
@@ -39,5 +37,5 @@ export function createMessageManager(
     logger.debug(
         `Creating MessageManager for ${provider}/${model} using ${router} router with maxTokens: ${maxTokens}`
     );
-    return new MessageManager(formatter, contributors, maxTokens, tokenizer);
+    return new MessageManager(formatter, promptManager, maxTokens, tokenizer);
 }

--- a/src/ai/llm/services/README.md
+++ b/src/ai/llm/services/README.md
@@ -136,7 +136,6 @@ export class YourProviderService implements ILLMService {
         return this.clientManager.getAllTools();
     }
 
-
     resetConversation(): void {
         this.messageManager.reset(); // Reset keeps the system prompt by default
         this.eventEmitter.emit('llmservice:conversationReset'); // Use specific event names

--- a/src/ai/llm/services/README.md
+++ b/src/ai/llm/services/README.md
@@ -131,20 +131,11 @@ export class YourProviderService implements ILLMService {
         logger.info(`Initialized YourProviderService with model ${this.model}`);
     }
 
-    // --- Implement ILLMService Methods ---
-
-    getEventEmitter(): EventEmitter {
-        return this.eventEmitter;
-    }
 
     getAllTools(): Promise<ToolSet> {
         return this.clientManager.getAllTools();
     }
 
-    updateSystemContext(newSystemPrompt: string): void {
-        this.messageManager.setSystemPrompt(newSystemPrompt);
-        logger.debug('System context updated.');
-    }
 
     resetConversation(): void {
         this.messageManager.reset(); // Reset keeps the system prompt by default

--- a/src/ai/llm/services/anthropic.ts
+++ b/src/ai/llm/services/anthropic.ts
@@ -35,16 +35,8 @@ export class AnthropicService implements ILLMService {
         this.messageManager = messageManager;
     }
 
-    getEventEmitter(): EventEmitter {
-        return this.eventEmitter;
-    }
-
     getAllTools(): Promise<any> {
         return this.clientManager.getAllTools();
-    }
-
-    updateSystemContext(newSystemPrompt: string): void {
-        this.messageManager.setSystemPrompt(newSystemPrompt);
     }
 
     async completeTask(userInput: string, imageData?: ImageData): Promise<string> {

--- a/src/ai/llm/services/openai.ts
+++ b/src/ai/llm/services/openai.ts
@@ -35,16 +35,8 @@ export class OpenAIService implements ILLMService {
         this.messageManager = messageManager;
     }
 
-    getEventEmitter(): EventEmitter {
-        return this.eventEmitter;
-    }
-
     getAllTools(): Promise<ToolSet> {
         return this.clientManager.getAllTools();
-    }
-
-    updateSystemContext(newSystemPrompt: string): void {
-        this.messageManager.setSystemPrompt(newSystemPrompt);
     }
 
     async completeTask(userInput: string, imageData?: ImageData): Promise<string> {

--- a/src/ai/llm/services/types.ts
+++ b/src/ai/llm/services/types.ts
@@ -18,9 +18,6 @@ export interface ILLMService {
      */
     completeTask(userInput: string, imageData?: ImageData): Promise<string>;
 
-    // Update the system message/context
-    updateSystemContext(newSystemPrompt: string): void;
-
     // Clear conversation history
     resetConversation(): void;
 
@@ -29,9 +26,6 @@ export interface ILLMService {
 
     // Get configuration information about the LLM service
     getConfig(): LLMServiceConfig;
-
-    // Get event emitter for subscribing to events
-    getEventEmitter(): EventEmitter;
 }
 
 /**

--- a/src/ai/llm/services/vercel.ts
+++ b/src/ai/llm/services/vercel.ts
@@ -39,16 +39,8 @@ export class VercelLLMService implements ILLMService {
         );
     }
 
-    getEventEmitter(): EventEmitter {
-        return this.eventEmitter;
-    }
-
     getAllTools(): Promise<ToolSet> {
         return this.clientManager.getAllTools();
-    }
-
-    updateSystemContext(newSystemPrompt: string): void {
-        this.messageManager.setSystemPrompt(newSystemPrompt);
     }
 
     formatTools(tools: ToolSet): VercelToolSet {

--- a/src/ai/systemPrompt/contributors.ts
+++ b/src/ai/systemPrompt/contributors.ts
@@ -16,10 +16,10 @@ export class DynamicContributor implements SystemPromptContributor {
     constructor(
         public id: string,
         public priority: number,
-        private handler: (context: DynamicContributorContext) => Promise<string>
+        private promptGenerator: (context: DynamicContributorContext) => Promise<string>
     ) {}
 
     async getContent(context: DynamicContributorContext): Promise<string> {
-        return this.handler(context);
+        return this.promptGenerator(context);
     }
 }

--- a/src/ai/systemPrompt/loader.ts
+++ b/src/ai/systemPrompt/loader.ts
@@ -1,7 +1,7 @@
 import { ContributorConfig, SystemPromptConfig } from '../../config/types.js';
 import { SystemPromptContributor } from './types.js';
 import { StaticContributor, DynamicContributor } from './contributors.js';
-import { getSourceHandler } from './registry.js';
+import { getPromptGenerator } from './registry.js';
 
 export function loadContributors(
     systemPromptConfig: string | SystemPromptConfig
@@ -37,9 +37,10 @@ export function loadContributors(
             if (!c.content) throw new Error(`Static contributor "${c.id}" missing content`);
             return new StaticContributor(c.id, c.priority, c.content);
         } else if (c.type === 'dynamic' && c.source) {
-            const handler = getSourceHandler(c.source);
-            if (!handler) throw new Error(`No handler for dynamic contributor source: ${c.source}`);
-            return new DynamicContributor(c.id, c.priority, handler);
+            const promptGenerator = getPromptGenerator(c.source);
+            if (!promptGenerator)
+                throw new Error(`No handler for dynamic contributor source: ${c.source}`);
+            return new DynamicContributor(c.id, c.priority, promptGenerator);
         }
         throw new Error(`Invalid contributor config: ${JSON.stringify(c)}`);
     });

--- a/src/ai/systemPrompt/manager.ts
+++ b/src/ai/systemPrompt/manager.ts
@@ -79,6 +79,7 @@ export class PromptManager {
      * Register a new dynamic prompt generator at runtime.
      * Any already-loaded contributors referencing this source
      * will be instantiated and added immediately.
+     * This enables APIs to be built on top - to dynamically add new prompt generators
      */
     register(id: string, generator: DynamicPromptGenerator) {
         registerPromptGenerator(id, generator);

--- a/src/ai/systemPrompt/manager.ts
+++ b/src/ai/systemPrompt/manager.ts
@@ -1,0 +1,109 @@
+import type { ContributorConfig, SystemPromptConfig } from '../../config/types.js';
+import { StaticContributor } from './contributors.js';
+import { getPromptGenerator } from './registry.js';
+import { registerPromptGenerator } from './registry.js';
+import type { DynamicPromptGenerator } from './registry.js';
+import type { SystemPromptContributor, DynamicContributorContext } from './types.js';
+import { DynamicContributor } from './contributors.js';
+
+/**
+ * PromptManager orchestrates registration, loading, and composition
+ * of both static and dynamic system-prompt contributors.
+ */
+export class PromptManager {
+    private contributors: SystemPromptContributor[] = [];
+    private rawConfig: string | SystemPromptConfig;
+
+    constructor(config: string | SystemPromptConfig) {
+        this.load(config);
+    }
+
+    /**
+     * Load contributors from config (static + dynamic).
+     */
+    load(config: string | SystemPromptConfig) {
+        this.rawConfig = config;
+        // Inline loader logic from loader.ts:
+        const defaultContributors: ContributorConfig[] = [
+            { id: 'dateTime', type: 'dynamic', priority: 10, source: 'dateTime', enabled: true },
+        ];
+
+        let contributors: ContributorConfig[];
+        // basic prompt config - string
+        if (typeof config === 'string') {
+            // Always include default dynamic contributors (e.g. dateTime)
+            contributors = [
+                ...defaultContributors,
+                { id: 'legacyPrompt', type: 'static', priority: 0, content: config, enabled: true },
+            ];
+        } else {
+            // Start with default dynamic contributors
+            contributors = [...defaultContributors];
+            for (const userC of config.contributors) {
+                const idx = contributors.findIndex((c) => c.id === userC.id);
+                if (idx !== -1) contributors[idx] = userC;
+                else contributors.push(userC);
+            }
+            contributors = contributors.filter((c) => c.enabled !== false);
+        }
+        const instances = contributors.map((contributor) => {
+            if (contributor.type === 'static') {
+                if (!contributor.content)
+                    throw new Error(`Static contributor "${contributor.id}" missing content`);
+                return new StaticContributor(
+                    contributor.id,
+                    contributor.priority,
+                    contributor.content
+                );
+            } else if (contributor.type === 'dynamic' && contributor.source) {
+                const promptGenerator = getPromptGenerator(contributor.source);
+                if (!promptGenerator)
+                    throw new Error(
+                        `No generator registered for dynamic contributor source: ${contributor.source}`
+                    );
+                return new DynamicContributor(
+                    contributor.id,
+                    contributor.priority,
+                    promptGenerator
+                );
+            }
+            throw new Error(`Invalid contributor config: ${JSON.stringify(contributor)}`);
+        });
+        // Lower priority number first (0 = highest priority)
+        this.contributors = instances.sort((a, b) => a.priority - b.priority);
+    }
+
+    /**
+     * Register a new dynamic prompt generator at runtime.
+     * Any already-loaded contributors referencing this source
+     * will be instantiated and added immediately.
+     */
+    register(id: string, generator: DynamicPromptGenerator) {
+        registerPromptGenerator(id, generator);
+
+        if (typeof this.rawConfig !== 'string') {
+            for (const c of this.rawConfig.contributors) {
+                if (c.type === 'dynamic' && c.source === id) {
+                    this.contributors.push(new DynamicContributor(c.id, c.priority, generator));
+                }
+            }
+            // Maintain priority order (lower = higher priority)
+            this.contributors.sort((a, b) => a.priority - b.priority);
+        }
+    }
+
+    /**
+     * Build the full system prompt by invoking each contributor and concatenating.
+     */
+    async build(ctx: DynamicContributorContext): Promise<string> {
+        const parts = await Promise.all(this.contributors.map((c) => c.getContent(ctx)));
+        return parts.join('\n');
+    }
+
+    /**
+     * Expose current list of contributors (for inspection or testing).
+     */
+    getContributors(): SystemPromptContributor[] {
+        return this.contributors;
+    }
+}

--- a/src/ai/systemPrompt/registry.ts
+++ b/src/ai/systemPrompt/registry.ts
@@ -2,16 +2,21 @@ import * as handlers from './in-built-prompts.js';
 import { DynamicContributorContext } from './types.js';
 
 /**
- * This file contains the registry of all the source handlers for dynamic contributors for the system prompt.
+ * This file contains the registry of all the functions that can generate dynamic prompt pieces at runtime.
  */
-export type SourceHandler = (context: DynamicContributorContext) => Promise<string>;
+export type DynamicPromptGenerator = (context: DynamicContributorContext) => Promise<string>;
 
-export const sourceHandlerRegistry: Record<string, SourceHandler> = {
+export const dynamicPromptGenerators: Record<string, DynamicPromptGenerator> = {
     dateTime: handlers.getCurrentDateTime,
     memorySummary: handlers.getMemorySummary,
-    // Add other handlers here
-};
+    // Add other functions that generate prompts here
+} as const;
 
-export function getSourceHandler(source: string): SourceHandler | undefined {
-    return sourceHandlerRegistry[source];
+// This type is mainly for easier understanding of the code - links to ContributorConfig type
+export type PromptGeneratorKey = keyof typeof dynamicPromptGenerators;
+
+export function getPromptGenerator(
+    promptGeneratorKey: PromptGeneratorKey
+): DynamicPromptGenerator | undefined {
+    return dynamicPromptGenerators[promptGeneratorKey];
 }

--- a/src/ai/systemPrompt/registry.ts
+++ b/src/ai/systemPrompt/registry.ts
@@ -23,6 +23,7 @@ export function getPromptGenerator(
 }
 
 // To register a new prompt generator function
+// Can be useful for plugins build on top of saiki to add new prompt generators
 export function registerPromptGenerator(
     promptGeneratorKey: string,
     promptGenerator: DynamicPromptGenerator

--- a/src/ai/systemPrompt/registry.ts
+++ b/src/ai/systemPrompt/registry.ts
@@ -15,8 +15,17 @@ export const dynamicPromptGenerators: Record<string, DynamicPromptGenerator> = {
 // This type is mainly for easier understanding of the code - links to ContributorConfig type
 export type PromptGeneratorKey = keyof typeof dynamicPromptGenerators;
 
+// To fetch a prompt generator function from its name
 export function getPromptGenerator(
     promptGeneratorKey: PromptGeneratorKey
 ): DynamicPromptGenerator | undefined {
     return dynamicPromptGenerators[promptGeneratorKey];
+}
+
+// To register a new prompt generator function
+export function registerPromptGenerator(
+    promptGeneratorKey: string,
+    promptGenerator: DynamicPromptGenerator
+) {
+    dynamicPromptGenerators[promptGeneratorKey] = promptGenerator;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { LLMRouter } from '../ai/llm/types.js';
+import type { PromptGeneratorKey } from '../ai/systemPrompt/registry.js';
 
 /**
  * Configuration for stdio-based MCP server connections
@@ -58,7 +59,7 @@ export interface ContributorConfig {
     priority: number;
     enabled?: boolean;
     content?: string; // for static
-    source?: string; // for dynamic
+    source?: PromptGeneratorKey; // for dynamic, must be a valid key in dynamicPromptGenerators
 }
 
 export interface SystemPromptConfig {

--- a/src/utils/service-initializer.ts
+++ b/src/utils/service-initializer.ts
@@ -35,7 +35,7 @@ import { LLMRouter } from '../ai/llm/types.js';
 import { MessageManager } from '../ai/llm/messages/manager.js';
 import { createMessageManager } from '../ai/llm/messages/factory.js';
 import { createToolConfirmationProvider } from '../client/tool-confirmation/factory.js';
-import { loadContributors } from '../ai/systemPrompt/loader.js';
+import { PromptManager } from '../ai/systemPrompt/manager.js';
 import { loadConfigFile } from '../config/loader.js';
 import { ConfigManager } from '../config/manager.js';
 import type { CLIConfigOverrides } from '../config/types.js';
@@ -117,9 +117,9 @@ export async function createAgentServices(
 
     // 5. Initialize message manager
     const router: LLMRouter = config.llm.router ?? 'vercel';
-    const contributors = loadContributors(config.llm.systemPrompt);
+    const promptManager = new PromptManager(config.llm.systemPrompt);
     const messageManager =
-        overrides?.messageManager ?? createMessageManager(config.llm, router, contributors);
+        overrides?.messageManager ?? createMessageManager(config.llm, router, promptManager);
 
     // 6. Initialize LLM service
     const llmService =

--- a/src/utils/service-initializer.ts
+++ b/src/utils/service-initializer.ts
@@ -45,6 +45,7 @@ import type { CLIConfigOverrides } from '../config/types.js';
  */
 export type AgentServices = {
     clientManager: MCPClientManager;
+    promptManager: PromptManager;
     llmService: ILLMService;
     agentEventBus: EventEmitter;
     messageManager: MessageManager;
@@ -115,13 +116,15 @@ export async function createAgentServices(
             : 'Client manager and MCP servers initialized'
     );
 
-    // 5. Initialize message manager
-    const router: LLMRouter = config.llm.router ?? 'vercel';
+    // 5. Initialize prompt manager
     const promptManager = new PromptManager(config.llm.systemPrompt);
+
+    // 6. Initialize message manager
+    const router: LLMRouter = config.llm.router ?? 'vercel';
     const messageManager =
         overrides?.messageManager ?? createMessageManager(config.llm, router, promptManager);
 
-    // 6. Initialize LLM service
+    // 7. Initialize LLM service
     const llmService =
         overrides?.llmService ??
         createLLMService(config.llm, router, clientManager, agentEventBus, messageManager);
@@ -131,6 +134,13 @@ export async function createAgentServices(
             : `LLM service initialized using router: ${router}`
     );
 
-    // 7. Return the full service graph, including the ConfigManager
-    return { clientManager, llmService, agentEventBus, messageManager, configManager };
+    // 8. Return the full service
+    return {
+        clientManager,
+        promptManager,
+        llmService,
+        agentEventBus,
+        messageManager,
+        configManager,
+    };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,5 @@ export default defineConfig({
         environment: 'node',
         include: ['**/*.test.ts', '**/*.spec.ts'],
         watch: true,
-        threads: true,
     },
 });


### PR DESCRIPTION
Previously, prompt config logic was just through functions

Added a new PromptManager class which handles loading from config, registering new prompt contributors and building the system prompt.

This does 2 things:
1. Moves system prompt assembly logic out of the messagemanager and into its own dedicated class
2. Enables us to dynamically register prompt contributors AT RUNTIME with the new `registerPromptGenerator` function and gives us one place to manage anything system prompt related

Also made some other minor refactors (renaming some variables, removed some unused code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized prompt manager for system prompts, allowing for dynamic registration and assembly of prompt contributors.
- **Refactor**
  - Streamlined event subscription and system prompt management, consolidating logic for improved maintainability.
  - Updated various service interfaces and classes to use the new prompt manager instead of individual contributors.
  - Enhanced type safety for system prompt configuration.
- **Chores**
  - Removed unused methods and configuration options to simplify codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->