### PR TITLE
replace hardcoded dist server with public server

### DIFF
--- a/configuration/examples/website_designer.yml
+++ b/configuration/examples/website_designer.yml
@@ -9,9 +9,10 @@ mcpServers:
       - .
   puppeteer:
     type: stdio
-    command: node
+    command: npx
     args:
-      - dist/src/servers/puppeteerServer.js
+      - -y
+      - "@truffle-ai/puppeteer-server"
 
 # # describes the llm configuration
 llm:

--- a/configuration/saiki.yml
+++ b/configuration/saiki.yml
@@ -9,9 +9,10 @@ mcpServers:
       - .
   puppeteer:
     type: stdio
-    command: node
+    command: npx
     args:
-      - dist/src/servers/puppeteerServer.js
+      - -y
+      - "@truffle-ai/puppeteer-server"
 
 # # describes the llm configuration
 llm:


### PR DESCRIPTION
we published puppeteer server here: https://github.com/truffle-ai/mcp-servers/tree/main/src/puppeteer

this is to switch to this server to avoid hacky direct paths within our repo