### PR TITLE
Update readme to have deepwiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
   <img src="https://img.shields.io/badge/Status-Beta-yellow" alt="Status: Beta">
   <img src="https://img.shields.io/badge/License-Elastic%202.0-blue.svg" alt="License: Elastic License 2.0">
   <a href="https://discord.gg/GwxwQs8CN5"><img src="https://img.shields.io/badge/Discord-Join%20Chat-7289da?logo=discord&logoColor=white&style=flat" alt="Discord"></a>
+  <a href="https://deepwiki.com/truffle-ai/saiki"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
+
 
 **Use natural language to control your tools, apps, and services — connect once, command everything.**
 


### PR DESCRIPTION
Deepwiki has auto generated documentation for Saiki: https://deepwiki.com/truffle-ai/saiki
Linking that in our repo - this will refresh the docs weekly

src: https://deepwiki.com/truffle-ai/saiki