### PR TITLE
Link github pages to deepwiki

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://deepwiki.com/truffle-ai/saiki" />
+    <title>Redirecting to docs…</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="https://deepwiki.com/truffle-ai/saiki">our docs</a>…</p>
+  </body>
+</html> 


### PR DESCRIPTION
This sets up routing for current github pages to deepwiki