### PR TITLE
Updated dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,48 +3,63 @@
 ARG NODE_VERSION=20.18.1
 
 ################################################################################
-# Build stage - includes dev dependencies
+# Build stage - optimized for smaller final image
 FROM node:${NODE_VERSION}-alpine AS builder
+
+# Install build dependencies for native modules
+RUN apk add --no-cache \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files first for better caching
 COPY package*.json ./
 
-# Install all dependencies (dev + prod) for building
-RUN npm install --include=dev --ignore-scripts
+# Install dependencies - allow scripts for native modules
+RUN npm ci --include=dev
 
 # Copy source and build
 COPY . .
-RUN npm run build && npm prune --production
+RUN npm run build
+
+# Clean up and prepare production node_modules with native bindings
+RUN npm prune --production && \
+    npm cache clean --force && \
+    rm -rf /root/.npm /tmp/* /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html /usr/lib/node_modules/npm/scripts
 
 ################################################################################
-# Production stage - minimal runtime
+# Production stage - minimal Alpine with Chromium
 FROM node:${NODE_VERSION}-alpine AS production
 
-# Install Chromium for puppeteer server
+# Install only essential Chromium dependencies in single layer
 RUN apk add --no-cache \
     chromium \
-    harfbuzz \
-    nss \
-    freetype \
-    ttf-freefont
+    && rm -rf /var/cache/apk/* /tmp/*
 
 WORKDIR /app
 
 # Create non-root user
 RUN addgroup -g 1001 -S saiki && adduser -S saiki -u 1001
 
-# Copy only production files
+# Create .saiki directory with proper permissions for database
+RUN mkdir -p /app/.saiki/database && \
+    chown -R saiki:saiki /app/.saiki
+
+# Copy only essential production files
 COPY --from=builder --chown=saiki:saiki /app/dist ./dist
 COPY --from=builder --chown=saiki:saiki /app/node_modules ./node_modules
 COPY --from=builder --chown=saiki:saiki /app/package.json ./
 COPY --from=builder --chown=saiki:saiki /app/configuration ./configuration
 
 # Environment variables
-ENV NODE_ENV=production
-ENV PORT=3000
-ENV CONFIG_FILE=/app/configuration/saiki.yml
+ENV NODE_ENV=production \
+    PORT=3000 \
+    CONFIG_FILE=/app/configuration/saiki.yml \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Switch to non-root user
 USER saiki
@@ -57,4 +72,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 EXPOSE $PORT
 
 # Server mode: REST APIs + WebSocket on single port
-CMD node dist/src/app/index.js --mode server --web-port $PORT --config-file $CONFIG_FILE 
+CMD ["sh", "-c", "node dist/src/app/index.js --mode server --web-port $PORT --config-file $CONFIG_FILE"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,60 @@
-# syntax=docker/dockerfile:1
-
-# Comments are provided throughout this file to help you get started.
-# If you need more help, visit the Dockerfile reference guide at
-# https://docs.docker.com/go/dockerfile-reference/
-
-# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
-
+################################################################################
+# Build stage - includes dev dependencies
 ARG NODE_VERSION=20.18.1
 
 ################################################################################
-# Use node image for base image for all stages.
-FROM node:${NODE_VERSION}-alpine AS base
+# Build stage - includes dev dependencies
+FROM node:${NODE_VERSION}-alpine AS builder
 
-# Set working directory for all build stages.
-WORKDIR /usr/src/app
+WORKDIR /app
 
+# Copy package files
+COPY package*.json ./
 
-################################################################################
-# Create a stage for installing production dependecies.
-FROM base AS deps
+# Install all dependencies (dev + prod) for building
+RUN npm install --include=dev --ignore-scripts
 
-# Download dependencies as a separate step to take advantage of Docker's caching.
-# Leverage a cache mount to /root/.npm to speed up subsequent builds.
-# Leverage bind mounts to package.json and package-lock.json to avoid having to copy them
-# into this layer.
-RUN --mount=type=bind,source=package.json,target=package.json \
-    --mount=type=bind,source=package-lock.json,target=package-lock.json \
-    --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
-
-################################################################################
-# Create a stage for building the application.
-FROM deps AS build
-
-# Download additional development dependencies before building, as some projects require
-# "devDependencies" to be installed to build. If you don't need this, remove this step.
-RUN --mount=type=bind,source=package.json,target=package.json \
-    --mount=type=bind,source=package-lock.json,target=package-lock.json \
-    --mount=type=cache,target=/root/.npm \
-    npm ci
-
-# Copy the rest of the source files into the image.
+# Copy source and build
 COPY . .
-# Run the build script.
-RUN npm run build
+RUN npm run build && npm prune --production
 
 ################################################################################
-# Create a new stage to run the application with minimal runtime dependencies
-# where the necessary files are copied from the build stage.
-FROM base AS final
+# Production stage - minimal runtime
+FROM node:${NODE_VERSION}-alpine AS production
 
-# Use production node environment by default.
+# Install Chromium for puppeteer server
+RUN apk add --no-cache \
+    chromium \
+    harfbuzz \
+    nss \
+    freetype \
+    ttf-freefont
+
+WORKDIR /app
+
+# Create non-root user
+RUN addgroup -g 1001 -S saiki && adduser -S saiki -u 1001
+
+# Copy only production files
+COPY --from=builder --chown=saiki:saiki /app/dist ./dist
+COPY --from=builder --chown=saiki:saiki /app/node_modules ./node_modules
+COPY --from=builder --chown=saiki:saiki /app/package.json ./
+COPY --from=builder --chown=saiki:saiki /app/configuration ./configuration
+
+# Environment variables
 ENV NODE_ENV=production
+ENV PORT=3000
+ENV CONFIG_FILE=/app/configuration/saiki.yml
 
-# Run the application as a non-root user.
-USER node
+# Switch to non-root user
+USER saiki
 
-# Copy package.json so that package manager commands can be used.
-COPY package.json .
-# Copy configuration files
-COPY configuration ./configuration
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD node -e "const http = require('http'); const req = http.request({host:'localhost',port:process.env.PORT||3000,path:'/health'}, (res) => process.exit(res.statusCode === 200 ? 0 : 1)); req.on('error', () => process.exit(1)); req.end();"
 
-# Copy the production dependencies from the deps stage and also
-# the built application from the build stage into the image.
-COPY --from=deps /usr/src/app/node_modules ./node_modules
-COPY --from=build /usr/src/app/dist ./dist
+# Single port for deployment platform
+EXPOSE $PORT
 
-
-# Expose the port that the application listens on.
-EXPOSE 3000
-
-# Run the application.
-ENTRYPOINT ["npm", "start"]
-CMD []
+# Server mode: REST APIs + WebSocket on single port
+CMD node dist/src/app/index.js --mode server --web-port $PORT --config-file $CONFIG_FILE 

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,107 +1,45 @@
 # Running Saiki with Docker
 
-This guide explains how to build and run Saiki using Docker, including advanced options for mounting your project directory and setting the working directory.
+Simple guide to run Saiki server with Docker.
 
----
+## Setup
 
-## 1. Build the Docker image
+1. **Build the image**
+   ```bash
+   docker build -t saiki .
+   ```
 
-Make sure Docker desktop is running and then run
+2. **Create .env file**
+   Add your API keys (see main README for details)
 
-```bash
-docker build -t saiki .
-```
-
-## 2. Prepare your environment
-
-Make sure you have a `.env` file in your project root with your API keys (see the main README for details).
-
-## 3. Run Saiki in CLI mode (interactive)
+## Run Saiki Server
 
 ```bash
-docker run -it --env-file .env saiki
+docker run --env-file .env -p 3000:3000 saiki
 ```
-- The `-it` flag gives you an interactive terminal for the CLI.
-- You can also pass CLI arguments, for example:
-  ```bash
-  docker run -it --env-file .env saiki -- --config-file configuration/saiki.yml
-  ```
 
-## 4. Run Saiki in Web UI mode
+Access the API at: http://localhost:3000
+
+## Custom Port
 
 ```bash
-docker run --env-file .env -p 3000:3000 saiki -- --mode web
-```
-- Access the Web UI at [http://localhost:3000](http://localhost:3000).
-- To use a custom port:
-  ```bash
-  docker run --env-file .env -p 8080:8080 saiki -- --mode web --web-port 8080
-  ```
-
-## 5. (Optional) Mount your project directory and set the working directory
-
-If you want Saiki (and its MCP servers) to access files from your host machine, you can mount your project directory into the container and set the working directory at runtime:
-
-**On Linux/macOS:**
-```bash
-docker run -it --env-file .env -v ~/Projects/saiki:/workspace -w /workspace saiki
-```
-- `-v ~/Projects/saiki:/workspace` mounts your local project directory into the container at `/workspace`.
-- `-w /workspace` sets the working directory inside the container to `/workspace`.
-
-**On Windows (Command Prompt):**
-```cmd
-docker run -it --env-file .env -v C:\Users\<YourUsername>\Projects\saiki:/workspace -w /workspace saiki
-```
-- Use your actual Windows username and path.
-- If using PowerShell, you may need to quote the path:
-  ```powershell
-  docker run -it --env-file .env -v "C:\Users\<YourUsername>\Projects\saiki:/workspace" -w /workspace saiki
-  ```
-- If using Git Bash or WSL, you may use `/c/Users/<YourUsername>/Projects/saiki:/workspace` as the path.
-
-This allows Saiki and its tool servers (like Filesystem MCP) to see and operate on your local files, just like when running outside Docker.
-
-## 6. Passing Environment Variables (e.g., API keys)
-
-You can also pass environment variables directly:
-
-```bash
-docker run -e OPENAI_API_KEY=your_openai_api_key -p 3000:3000 saiki -- --mode web
+docker run --env-file .env -p 8080:8080 -e PORT=8080 saiki
 ```
 
-## 7. Docker Compose & Cloud Deployment
-
-### Docker Compose
-
-When you're ready, you can start your application with Docker Compose.
-You can update compose.yaml accordingly based on the containers you want, we have a sample file to get started.
+## Docker Compose
 
 ```bash
 docker compose up --build
 ```
 
-Your application will be available at http://localhost:3000.
-
-You can also override the command in Docker Compose using the `command:` field.
-
-### Deploying to the Cloud
-
-First, build your image for the appropriate platform (if needed):
+## Cloud Deployment
 
 ```bash
-docker build --platform=linux/amd64 -t myapp .
+# Build for production
+docker build --platform=linux/amd64 -t saiki .
+
+# Push to registry
+docker push your-registry.com/saiki
 ```
 
-Then, push it to your registry:
-
-```bash
-docker push myregistry.com/myapp
-```
-
-Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/) docs for more detail on building and pushing images.
-
-## 8. References
-
-- [Docker's Node.js guide](https://docs.docker.com/language/nodejs/)
-- See the main [README.md](./README.md) for more details on configuration and usage.
+That's it. Saiki runs in server mode with REST API + WebSocket on the specified port.

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -15,21 +15,38 @@ Simple guide to run Saiki server with Docker.
 ## Run Saiki Server
 
 ```bash
-docker run --env-file .env -p 3000:3000 saiki
+docker run --env-file .env -p 3001:3001 saiki
 ```
 
-Access the API at: http://localhost:3000
+The server will start on port 3001 with:
+- ✅ SQLite database connected
+- ✅ MCP servers (filesystem & puppeteer) connected
+- ✅ REST API + WebSocket endpoints available
 
-## Custom Port
+## Access Your Server
 
-```bash
-docker run --env-file .env -p 8080:8080 -e PORT=8080 saiki
-```
+- **API Endpoints:** http://localhost:3001/api/
+- **Health Check:** http://localhost:3001/health
+- **MCP Servers:** http://localhost:3001/api/mcp/servers
+
+## Available API Endpoints
+
+- `POST /api/message` - Send async message
+- `POST /api/message-sync` - Send sync message
+- `POST /api/reset` - Reset conversation
+- `GET /api/mcp/servers` - List MCP servers
+- WebSocket support for real-time events
 
 ## Docker Compose
 
 ```bash
 docker compose up --build
+```
+
+## Background Mode
+
+```bash
+docker run -d --env-file .env -p 3001:3001 saiki
 ```
 
 ## Cloud Deployment
@@ -42,4 +59,4 @@ docker build --platform=linux/amd64 -t saiki .
 docker push your-registry.com/saiki
 ```
 
-That's it. Saiki runs in server mode with REST API + WebSocket on the specified port.
+That's it! Saiki runs in server mode with REST API + WebSocket on port 3001.

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - 3000:3000
+      - 3001:3001
 
 # The commented out section below is an example of how to define a PostgreSQL
 # database that your application can use. `depends_on` tells Docker Compose to

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -38,6 +38,12 @@ export async function initializeApi(agent: SaikiAgent, agentCardOverride?: Parti
     webSubscriber.subscribe(agent.agentEventBus);
 
     // HTTP endpoints
+
+    // Health check endpoint
+    app.get('/health', (req, res) => {
+        res.status(200).send('OK');
+    });
+
     app.post('/api/message', express.json(), async (req, res) => {
         logger.info('Received message via POST /api/message');
         if (!req.body || !req.body.message) {


### PR DESCRIPTION
Cleaned up dockerfile for serving the agents. Pruned the docker image and deployment to only serve the agent in server mode for now and reduced the image size. 

We can the webui deployment strategy back later once we clean up the repository structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined the Dockerfile with a simplified two-stage build, improved security by running as a non-root user, added a health check endpoint, and updated container startup commands.

- **Documentation**
  - Simplified Docker usage instructions to a minimal setup emphasizing server mode on port 3001, added API endpoint references, and clarified cloud deployment steps.

- **New Features**
  - Added a health check endpoint (`/health`) to monitor API server status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->