### PR TITLE
remove DEBUG env variable, fix logging env config, remove puppeteer core dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,7 @@ COPY --from=builder --chown=saiki:saiki /app/configuration ./configuration
 # Environment variables
 ENV NODE_ENV=production \
     PORT=3000 \
-    CONFIG_FILE=/app/configuration/saiki.yml \
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+    CONFIG_FILE=/app/configuration/saiki.yml
 
 # Switch to non-root user
 USER saiki

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,9 @@ COPY --from=builder --chown=saiki:saiki /app/configuration ./configuration
 # Environment variables
 ENV NODE_ENV=production \
     PORT=3000 \
-    CONFIG_FILE=/app/configuration/saiki.yml
+    CONFIG_FILE=/app/configuration/saiki.yml \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Switch to non-root user
 USER saiki

--- a/docs/docs/guides/configuring-saiki/mcpServers.md
+++ b/docs/docs/guides/configuring-saiki/mcpServers.md
@@ -49,8 +49,6 @@ mcpServers:
     command: node
     args:
       - dist/src/servers/puppeteerServer.js
-    env:
-      DEBUG: "puppeteer:*"
     timeout: 30000
 ```
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
         "openai": "^4.89.0",
         "ora": "^7.0.1",
         "pg": "^8.16.0",
-        "puppeteer-core": "^24.4.0",
         "readline-sync": "^1.4.10",
         "rimraf": "^6.0.1",
         "tiktoken": "^1.0.21",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
+// Load environment variables FIRST, before any other imports
+import dotenv from 'dotenv';
+dotenv.config();
+
 import { existsSync } from 'fs';
 import { Command } from 'commander';
-import dotenv from 'dotenv';
 import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import pkg from '../../package.json' with { type: 'json' };
@@ -36,15 +39,8 @@ import { checkForFileInCurrentDirectory, FileNotFoundError } from './cli/utils/p
 import { startNextJsWebServer } from './web.js';
 import { initializeMcpServer, createMcpTransport } from './api/mcp/mcp_handler.js';
 import { createAgentCard } from '@core/config/agentCard.js';
-// Load environment variables
-dotenv.config();
 
 const program = new Command();
-
-// Universal stuff
-if (process.env.SAIKI_LOG_LEVEL) {
-    logger.setLevel(process.env.SAIKI_LOG_LEVEL);
-}
 
 // 1) GLOBAL OPTIONS
 program

--- a/src/core/logger/logger.ts
+++ b/src/core/logger/logger.ts
@@ -88,10 +88,6 @@ const getDefaultLogLevel = (): string => {
     if (envLevel && Object.keys(logLevels).includes(envLevel.toLowerCase())) {
         return envLevel.toLowerCase();
     }
-    // Enable debug logging if DEBUG environment variable is set
-    if (process.env.DEBUG === 'true' || process.env.DEBUG === '1') {
-        return 'debug';
-    }
     return 'info';
 };
 


### PR DESCRIPTION
puppeteer is moved to mcp server so we don't need it anymore
DEBUG env variable was conflicting with SAIKI_LOG_LEVEL

moved `dotenv.config()` to start of the app so that `SAIKI_LOG_LEVEL` is correctly parsed (prev was using debug logs even in info mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration guide to remove the example setting of the DEBUG environment variable for Puppeteer in the MCP server documentation.

- **Chores**
  - Removed the "puppeteer-core" dependency from the project.

- **Refactor**
  - Changed the order of environment variable loading for improved reliability.
  - Simplified log level configuration by removing support for the DEBUG environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->