### PR TITLE
update mcp command to require --group-servers and fix path logic 

### DIFF
--- a/docs/docs/guides/cli.md
+++ b/docs/docs/guides/cli.md
@@ -105,6 +105,20 @@ With this, you can now connect this agent to Cursor, claude desktop, or even oth
 
 Check [Using saiki as an MCP Server](./mcp/saiki-agent-as-mcp-server.md) to understand more about MCP servers.
 
+#### **Group MCP servers with saiki**
+```bash
+saiki mcp --group-servers
+```
+
+This starts Saiki as an MCP server that aggregates and re-exposes tools from multiple configured MCP servers. This is useful when you want to access tools from multiple MCP servers through a single connection.
+
+To use a specific config file:
+```bash
+saiki mcp --group-servers -a ./saiki-tools.yml
+```
+
+Check [Using Saiki to group MCP servers](./mcp/saiki-group-mcp-servers.md) to understand more about MCP server aggregation.
+
 
 #### **Change log level for saiki CLI**
 

--- a/docs/docs/guides/mcp/saiki-group-mcp-servers.md
+++ b/docs/docs/guides/mcp/saiki-group-mcp-servers.md
@@ -63,7 +63,8 @@ Add the following to your `.cursor/mcp.json` file:
         "-y", 
         "@truffle-ai/saiki", 
         "mcp",
-        "-c", 
+        "--group-servers",
+        "-a",
         "path/to/your/saiki-tools.yml"
       ]
     }
@@ -82,6 +83,7 @@ Or use the default Saiki configuration
         "-y", 
         "@truffle-ai/saiki", 
         "mcp",
+        "--group-servers"
       ]
     }
   }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -137,19 +137,33 @@ program
 program
     .command('mcp')
     .description(
-        'Start Saiki as an MCP server. By default, this command aggregates and re-exposes tools from configured MCP servers. \
-        Use `saiki mcp-` to start Saiki as an MCP tool aggregator'
+        'Start Saiki as an MCP server. Use --group-servers to aggregate and re-expose tools from configured MCP servers. \
+        In the future, this command will expose the agent as an MCP server by default.'
     )
-    .option('-a, --agent <path>', 'Path to agent config file', DEFAULT_CONFIG_PATH)
     .option('-s, --strict', 'Require all MCP server connections to succeed')
+    .option(
+        '--group-servers',
+        'Aggregate and re-expose tools from configured MCP servers (required for now)'
+    )
     .option('--name <name>', 'Name for the MCP server', 'saiki-tools')
     .option('--version <version>', 'Version for the MCP server', '1.0.0')
     .action(async (options) => {
         try {
+            // Validate that --group-servers flag is provided (mandatory for now)
+            if (!options.groupServers) {
+                logger.error(
+                    'The --group-servers flag is required. This command currently only supports aggregating and re-exposing tools from configured MCP servers.'
+                );
+                logger.info('Usage: saiki mcp --group-servers');
+                process.exit(1);
+            }
+
             // Load and resolve config
+            // Get the global agent option from the main program
+            const globalOpts = program.opts();
             const configPath = resolvePackagePath(
-                options.agent || DEFAULT_CONFIG_PATH,
-                (options.agent || DEFAULT_CONFIG_PATH) === DEFAULT_CONFIG_PATH
+                globalOpts.agent || DEFAULT_CONFIG_PATH,
+                (globalOpts.agent || DEFAULT_CONFIG_PATH) === DEFAULT_CONFIG_PATH
             );
 
             logger.info(`Loading Saiki config from: ${configPath}`);
@@ -212,7 +226,7 @@ program
             'Run saiki as a discord bot with `saiki --mode discord`\n' +
             'Run saiki as a telegram bot with `saiki --mode telegram`\n' +
             'Run saiki agent as an MCP server with `saiki --mode mcp`\n' +
-            'Run saiki as an MCP server aggregator with `saiki mcp`\n\n' +
+            'Run saiki as an MCP server aggregator with `saiki mcp --group-servers`\n\n' +
             'Check subcommands for more features. Check https://github.com/truffle-ai/saiki for documentation on how to customize saiki and other examples'
     )
     .action(async (prompt: string[] = []) => {


### PR DESCRIPTION
previously, commander was failing with the same option in sub-command and main command so we had to get rid of the subcommand argument and use globalOptions.

also enforced --group-servers to be on as intermediate step to migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI documentation to describe the new required --group-servers flag for running Saiki as a grouped MCP server.
  - Revised configuration examples and command-line instructions to reflect updated CLI usage and options.

- **New Features**
  - Introduced a new --group-servers flag to the CLI for aggregating tools from multiple MCP servers.

- **Bug Fixes**
  - Improved error handling by requiring the --group-servers flag and providing clearer usage instructions.

- **Refactor**
  - Removed the -a, --agent option from the mcp sub-command and updated help text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->