### PR TITLE
Update gemini model names to stable versions

### DIFF
--- a/src/app/webui/components/InputArea.tsx
+++ b/src/app/webui/components/InputArea.tsx
@@ -41,7 +41,7 @@ export default function InputArea({ onSend, isSending }: InputAreaProps) {
     { name: 'Claude 4 Sonnet', provider: 'anthropic', model: 'claude-4-sonnet-20250514' },
     { name: 'GPT-4o', provider: 'openai', model: 'gpt-4o' },
     { name: 'GPT-4.1 Mini', provider: 'openai', model: 'gpt-4.1-mini' },
-    { name: 'Gemini 2.5 Pro', provider: 'google', model: 'gemini-2.5-pro-exp-03-25' },
+    { name: 'Gemini 2.5 Pro', provider: 'google', model: 'gemini-2.5-pro' },
   ];
 
   // Fetch current LLM configuration

--- a/src/core/ai/agent/SaikiAgent.test.ts
+++ b/src/core/ai/agent/SaikiAgent.test.ts
@@ -413,7 +413,7 @@ describe('SaikiAgent.switchLLM', () => {
         test('should pass all parameters to validation', async () => {
             await agent.switchLLM({
                 provider: 'google',
-                model: 'gemini-2.5-pro-exp-03-25',
+                model: 'gemini-2.5-pro',
                 apiKey: 'custom-key',
                 router: 'vercel',
                 baseURL: 'https://custom.api.com',
@@ -422,7 +422,7 @@ describe('SaikiAgent.switchLLM', () => {
             expect(mockValidationUtils.buildLLMConfig).toHaveBeenCalledWith(
                 {
                     provider: 'google',
-                    model: 'gemini-2.5-pro-exp-03-25',
+                    model: 'gemini-2.5-pro',
                     apiKey: 'custom-key',
                     router: 'vercel',
                     baseURL: 'https://custom.api.com',

--- a/src/core/ai/llm/registry.ts
+++ b/src/core/ai/llm/registry.ts
@@ -58,8 +58,8 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
     },
     google: {
         models: [
-            { name: 'gemini-2.5-pro-exp-03-25', maxInputTokens: 1048576, default: true },
-            { name: 'gemini-2.5-flash-preview-05-20', maxInputTokens: 1048576 },
+            { name: 'gemini-2.5-pro', maxInputTokens: 1048576, default: true },
+            { name: 'gemini-2.5-flash', maxInputTokens: 1048576 },
             { name: 'gemini-2.0-flash', maxInputTokens: 1048576 },
             { name: 'gemini-2.0-flash-lite', maxInputTokens: 1048576 },
             { name: 'gemini-1.5-pro-latest', maxInputTokens: 1048576 },

--- a/src/core/config/validation-utils.test.ts
+++ b/src/core/config/validation-utils.test.ts
@@ -125,9 +125,9 @@ describe('buildLLMConfig', () => {
         expect(result.isValid).toBe(true);
         expect(result.config.provider).toBe('google');
         // Should switch to default Google model from registry
-        expect(result.config.model).toBe('gemini-2.5-pro-exp-03-25'); // Default Google model
+        expect(result.config.model).toBe('gemini-2.5-pro'); // Default Google model
         expect(result.warnings).toContain(
-            "Switched to default model 'gemini-2.5-pro-exp-03-25' for provider 'google'"
+            "Switched to default model 'gemini-2.5-pro' for provider 'google'"
         );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the naming of Gemini models to reflect the latest identifiers, including setting "gemini-2.5-pro" as the default and renaming "gemini-2.5-flash-preview-05-20" to "gemini-2.5-flash".

* **Tests**
  * Adjusted test cases to use the updated Gemini model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->