### PR TITLE
Updated CLI to support slash commands 

### DIFF
--- a/src/app/cli/command-parser.ts
+++ b/src/app/cli/command-parser.ts
@@ -1,0 +1,137 @@
+import chalk from 'chalk';
+
+export interface CommandResult {
+    type: 'command' | 'prompt';
+    command?: string;
+    args?: string[];
+    rawInput?: string;
+}
+
+export interface CommandDefinition {
+    name: string;
+    description: string;
+    usage: string;
+    aliases?: string[];
+    subcommands?: CommandDefinition[];
+    handler: (args: string[], agent: any) => Promise<boolean>;
+}
+
+/**
+ * Parses user input to determine if it's a slash command or a regular prompt
+ */
+export function parseInput(input: string): CommandResult {
+    const trimmed = input.trim();
+
+    // Check if it's a slash command
+    if (trimmed.startsWith('/')) {
+        const parts = trimmed
+            .slice(1)
+            .split(' ')
+            .filter((part) => part.length > 0);
+        const command = parts[0] || '';
+        const args = parts.slice(1);
+
+        return {
+            type: 'command',
+            command,
+            args,
+            rawInput: trimmed,
+        };
+    }
+
+    // Regular user prompt
+    return {
+        type: 'prompt',
+        rawInput: input,
+    };
+}
+
+/**
+ * Finds command suggestions based on partial input
+ */
+export function getCommandSuggestions(partial: string, commands: CommandDefinition[]): string[] {
+    const suggestions: string[] = [];
+
+    for (const cmd of commands) {
+        // Check main command name
+        if (cmd.name.startsWith(partial)) {
+            suggestions.push(cmd.name);
+        }
+
+        // Check aliases
+        if (cmd.aliases) {
+            for (const alias of cmd.aliases) {
+                if (alias.startsWith(partial)) {
+                    suggestions.push(alias);
+                }
+            }
+        }
+    }
+
+    return suggestions.sort();
+}
+
+/**
+ * Formats help text for a command
+ */
+export function formatCommandHelp(cmd: CommandDefinition, detailed: boolean = false): string {
+    let help = chalk.cyan(`/${cmd.name}`) + ' - ' + cmd.description;
+
+    if (detailed) {
+        help += '\n' + chalk.dim(`Usage: ${cmd.usage}`);
+
+        if (cmd.aliases && cmd.aliases.length > 0) {
+            help += '\n' + chalk.dim(`Aliases: ${cmd.aliases.map((a) => `/${a}`).join(', ')}`);
+        }
+
+        if (cmd.subcommands && cmd.subcommands.length > 0) {
+            help += '\n' + chalk.dim('Subcommands:');
+            for (const sub of cmd.subcommands) {
+                help += '\n  ' + chalk.cyan(`/${cmd.name} ${sub.name}`) + ' - ' + sub.description;
+            }
+        }
+    }
+
+    return help;
+}
+
+/**
+ * Displays a formatted list of all available commands
+ */
+export function displayAllCommands(commands: CommandDefinition[]): void {
+    console.log(chalk.bold.green('\n📋 Available Commands:\n'));
+
+    const categories: { [key: string]: CommandDefinition[] } = {
+        'Session Management': [],
+        'Model Management': [],
+        System: [],
+        General: [],
+    };
+
+    // Categorize commands
+    for (const cmd of commands) {
+        if (cmd.name.startsWith('session')) {
+            categories['Session Management']!.push(cmd);
+        } else if (cmd.name.startsWith('model')) {
+            categories['Model Management']!.push(cmd);
+        } else if (['config', 'stats', 'log'].includes(cmd.name)) {
+            categories['System']!.push(cmd);
+        } else {
+            categories['General']!.push(cmd);
+        }
+    }
+
+    // Display by category
+    for (const [category, cmds] of Object.entries(categories)) {
+        if (cmds.length > 0) {
+            console.log(chalk.bold.yellow(`${category}:`));
+            for (const cmd of cmds) {
+                console.log('  ' + formatCommandHelp(cmd));
+            }
+            console.log();
+        }
+    }
+
+    console.log(chalk.dim('💡 Tip: Use /help <command> for detailed help on any command'));
+    console.log(chalk.dim('💡 Tip: Type your message normally (without /) to chat with the AI\n'));
+}

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -1,0 +1,716 @@
+import chalk from 'chalk';
+import { logger } from '@core/index.js';
+import { SaikiAgent } from '@core/index.js';
+import { CommandDefinition, formatCommandHelp, displayAllCommands } from './command-parser.js';
+
+/**
+ * Helper to format session information consistently
+ */
+function formatSessionInfo(sessionId: string, metadata?: any, isCurrent: boolean = false): string {
+    const prefix = isCurrent ? chalk.green('→') : ' ';
+    const name = isCurrent ? chalk.green.bold(sessionId) : chalk.cyan(sessionId);
+
+    let info = `${prefix} ${name}`;
+
+    if (metadata) {
+        const messages = metadata.messageCount || 0;
+        const activity = metadata.lastActivity
+            ? new Date(metadata.lastActivity).toLocaleString()
+            : 'Never';
+
+        info += chalk.dim(` (${messages} messages, last: ${activity})`);
+
+        if (isCurrent) {
+            info += chalk.yellow(' [ACTIVE]');
+        }
+    }
+
+    return info;
+}
+
+/**
+ * Helper to get current session info
+ */
+async function getCurrentSessionInfo(agent: SaikiAgent): Promise<{ id: string; metadata?: any }> {
+    const currentId = agent.getCurrentSessionId();
+    const metadata = await agent.getSessionMetadata(currentId);
+    return { id: currentId, metadata };
+}
+
+/**
+ * Helper to format conversation history
+ */
+function formatHistoryMessage(message: any, index: number): string {
+    const timestamp = message.timestamp
+        ? new Date(message.timestamp).toLocaleTimeString()
+        : `#${index + 1}`;
+
+    let roleColor = chalk.dim;
+    let roleLabel = message.role;
+
+    switch (message.role) {
+        case 'user':
+            roleColor = chalk.blue;
+            roleLabel = 'You';
+            break;
+        case 'assistant':
+            roleColor = chalk.green;
+            roleLabel = 'Assistant';
+            break;
+        case 'system':
+            roleColor = chalk.yellow;
+            roleLabel = 'System';
+            break;
+        case 'tool':
+            roleColor = chalk.magenta;
+            roleLabel = 'Tool';
+            break;
+    }
+
+    // Handle content formatting
+    let content = '';
+    if (typeof message.content === 'string') {
+        content = message.content;
+    } else if (Array.isArray(message.content)) {
+        // Handle multimodal content
+        content = message.content
+            .map((part: any) => {
+                if (part.type === 'text') return part.text;
+                if (part.type === 'image') return '[Image]';
+                return '[Unknown content]';
+            })
+            .join(' ');
+    } else {
+        content = '[No content]';
+    }
+
+    // Truncate very long messages
+    if (content.length > 200) {
+        content = content.substring(0, 200) + '...';
+    }
+
+    // Format tool calls if present
+    let toolInfo = '';
+    if (message.toolCalls && message.toolCalls.length > 0) {
+        const toolNames = message.toolCalls
+            .map((tc: any) => tc.function?.name || 'unknown')
+            .join(', ');
+        toolInfo = chalk.dim(` [Tools: ${toolNames}]`);
+    }
+
+    return `  ${chalk.dim(timestamp)} ${roleColor.bold(roleLabel)}: ${content}${toolInfo}`;
+}
+
+/**
+ * Session management commands
+ */
+const sessionCommands: CommandDefinition = {
+    name: 'session',
+    description: 'Manage chat sessions',
+    usage: '/session <subcommand> [args]',
+    aliases: ['s'],
+    subcommands: [
+        {
+            name: 'list',
+            description: 'List all sessions',
+            usage: '/session list',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                try {
+                    console.log(chalk.bold.blue('\n📋 Sessions:\n'));
+
+                    const sessionIds = await agent.listSessions();
+                    const current = await getCurrentSessionInfo(agent);
+
+                    if (sessionIds.length === 0) {
+                        console.log(
+                            chalk.dim('  No sessions found. Use /session new to create one.\n')
+                        );
+                        return true;
+                    }
+
+                    for (const sessionId of sessionIds) {
+                        const metadata = await agent.getSessionMetadata(sessionId);
+                        const isCurrent = sessionId === current.id;
+                        console.log('  ' + formatSessionInfo(sessionId, metadata, isCurrent));
+                    }
+
+                    console.log(chalk.dim(`\n  Total: ${sessionIds.length} sessions`));
+                    console.log(chalk.dim('  💡 Use /session switch <id> to change sessions\n'));
+                } catch (error) {
+                    logger.error(
+                        `Failed to list sessions: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
+            name: 'new',
+            description: 'Create a new session',
+            usage: '/session new [id]',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                try {
+                    const sessionId = args[0]; // Optional custom ID
+                    const session = await agent.createSession(sessionId);
+
+                    console.log(chalk.green(`✅ Created new session: ${chalk.bold(session.id)}`));
+
+                    // Switch to the new session
+                    await agent.loadSession(session.id);
+                    console.log(chalk.yellow(`🔄 Switched to new session`));
+                } catch (error) {
+                    logger.error(
+                        `Failed to create session: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
+            name: 'switch',
+            description: 'Switch to a different session',
+            usage: '/session switch <id>',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                if (args.length === 0) {
+                    console.log(chalk.red('❌ Session ID required. Usage: /session switch <id>'));
+                    return true;
+                }
+
+                try {
+                    const sessionId = args[0];
+                    if (!sessionId) {
+                        console.log(
+                            chalk.red('❌ Session ID required. Usage: /session switch <id>')
+                        );
+                        return true;
+                    }
+
+                    await agent.loadSession(sessionId);
+
+                    const metadata = await agent.getSessionMetadata(sessionId);
+                    console.log(chalk.green(`✅ Switched to session: ${chalk.bold(sessionId)}`));
+
+                    if (metadata && metadata.messageCount > 0) {
+                        console.log(chalk.dim(`   ${metadata.messageCount} messages in history`));
+                    } else {
+                        console.log(chalk.dim('   New conversation - no previous messages'));
+                    }
+                } catch (error) {
+                    logger.error(
+                        `Failed to switch session: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
+            name: 'current',
+            description: 'Show current session',
+            usage: '/session current',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                try {
+                    const current = await getCurrentSessionInfo(agent);
+                    console.log(chalk.blue('\n📍 Current Session:\n'));
+                    console.log('  ' + formatSessionInfo(current.id, current.metadata, true));
+                    console.log();
+                } catch (error) {
+                    logger.error(
+                        `Failed to get current session: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
+            name: 'history',
+            description: 'Show conversation history for current session',
+            usage: '/session history [sessionId]',
+            aliases: ['h'],
+            handler: async (args: string[], agent: SaikiAgent) => {
+                try {
+                    // Use provided session ID or current session
+                    const sessionId =
+                        args.length > 0 && args[0] ? args[0] : agent.getCurrentSessionId();
+
+                    console.log(
+                        chalk.blue(`\n💬 Conversation History for: ${chalk.bold(sessionId)}\n`)
+                    );
+
+                    const history = await agent.getSessionHistory(sessionId);
+
+                    if (history.length === 0) {
+                        console.log(chalk.dim('  No messages in this conversation yet.\n'));
+                        return true;
+                    }
+
+                    // Display each message with formatting
+                    history.forEach((message, index) => {
+                        console.log(formatHistoryMessage(message, index));
+                    });
+
+                    console.log(chalk.dim(`\n  Total: ${history.length} messages`));
+                    console.log(
+                        chalk.dim(
+                            '  💡 Use /clear to reset conversation or /session switch to change sessions\n'
+                        )
+                    );
+                } catch (error) {
+                    if (error instanceof Error && error.message.includes('not found')) {
+                        console.log(chalk.red(`❌ Session not found: ${args[0] || 'current'}`));
+                        console.log(chalk.dim('   Use /session list to see available sessions'));
+                    } else {
+                        logger.error(
+                            `Failed to get session history: ${error instanceof Error ? error.message : String(error)}`
+                        );
+                    }
+                }
+                return true;
+            },
+        },
+        {
+            name: 'delete',
+            description: 'Delete a session',
+            usage: '/session delete <id>',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                if (args.length === 0) {
+                    console.log(chalk.red('❌ Session ID required. Usage: /session delete <id>'));
+                    return true;
+                }
+
+                try {
+                    const sessionId = args[0];
+                    if (!sessionId) {
+                        console.log(
+                            chalk.red('❌ Session ID required. Usage: /session delete <id>')
+                        );
+                        return true;
+                    }
+
+                    const current = await getCurrentSessionInfo(agent);
+
+                    // Check if trying to delete current session
+                    if (sessionId === current.id) {
+                        console.log(
+                            chalk.yellow('⚠️  Cannot delete the currently active session.')
+                        );
+                        console.log(
+                            chalk.dim('   Switch to another session first, then delete this one.')
+                        );
+                        return true;
+                    }
+
+                    await agent.deleteSession(sessionId);
+                    console.log(chalk.green(`✅ Deleted session: ${chalk.bold(sessionId)}`));
+                } catch (error) {
+                    logger.error(
+                        `Failed to delete session: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+    ],
+    handler: async (args: string[], agent: SaikiAgent) => {
+        // Default to list if no subcommand
+        if (args.length === 0) {
+            const listSubcommand = sessionCommands.subcommands?.find((s) => s.name === 'list');
+            if (listSubcommand) {
+                return listSubcommand.handler([], agent);
+            }
+            return true;
+        }
+
+        const subcommand = args[0];
+        const subArgs = args.slice(1);
+
+        // Find matching subcommand
+        const subcmd = sessionCommands.subcommands?.find((s) => s.name === subcommand);
+        if (subcmd) {
+            return subcmd.handler(subArgs, agent);
+        }
+
+        console.log(chalk.red(`❌ Unknown session subcommand: ${subcommand}`));
+        console.log(
+            chalk.dim('Available subcommands: list, new, switch, current, history, delete')
+        );
+        return true;
+    },
+};
+
+/**
+ * Model management commands
+ */
+const modelCommands: CommandDefinition = {
+    name: 'model',
+    description: 'Manage AI models',
+    usage: '/model <subcommand> [args]',
+    aliases: ['m'],
+    subcommands: [
+        {
+            name: 'current',
+            description: 'Show current model configuration',
+            usage: '/model current',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                try {
+                    const config = agent.getEffectiveConfig();
+                    console.log(chalk.blue('\n🤖 Current Model Configuration:\n'));
+                    console.log(`  Provider: ${chalk.cyan(config.llm.provider)}`);
+                    console.log(`  Model: ${chalk.cyan(config.llm.model)}`);
+                    console.log(`  Router: ${chalk.cyan(config.llm.router)}`);
+
+                    if (config.llm.maxIterations) {
+                        console.log(
+                            `  Max Iterations: ${chalk.cyan(config.llm.maxIterations.toString())}`
+                        );
+                    }
+                    if (config.llm.maxInputTokens) {
+                        console.log(
+                            `  Max Input Tokens: ${chalk.cyan(config.llm.maxInputTokens.toString())}`
+                        );
+                    }
+                    console.log();
+                } catch (error) {
+                    logger.error(
+                        `Failed to get model info: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
+            name: 'switch',
+            description: 'Switch to a different model',
+            usage: '/model switch <model> [provider]',
+            handler: async (args: string[], agent: SaikiAgent) => {
+                if (args.length === 0) {
+                    console.log(
+                        chalk.red('❌ Model required. Usage: /model switch <model> [provider]')
+                    );
+                    return true;
+                }
+
+                try {
+                    const model = args[0];
+                    const provider = args[1];
+
+                    console.log(
+                        chalk.yellow(
+                            `🔄 Switching model to ${model}${provider ? ` (${provider})` : ''}...`
+                        )
+                    );
+
+                    const llmConfig: any = { model };
+                    if (provider) {
+                        llmConfig.provider = provider;
+                    }
+
+                    const result = await agent.switchLLM(llmConfig);
+
+                    if (result.success) {
+                        console.log(chalk.green(`✅ ${result.message}`));
+                        if (result.warnings && result.warnings.length > 0) {
+                            for (const warning of result.warnings) {
+                                console.log(chalk.yellow(`⚠️  ${warning}`));
+                            }
+                        }
+                    } else {
+                        console.log(chalk.red('❌ Failed to switch model:'));
+                        if (result.errors) {
+                            for (const error of result.errors) {
+                                console.log(chalk.red(`   ${error.message}`));
+                                if (error.suggestedAction) {
+                                    console.log(chalk.dim(`   💡 ${error.suggestedAction}`));
+                                }
+                            }
+                        }
+                    }
+                } catch (error) {
+                    logger.error(
+                        `Failed to switch model: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+    ],
+    handler: async (args: string[], agent: SaikiAgent) => {
+        // Default to current if no subcommand
+        if (args.length === 0) {
+            const currentSubcommand = modelCommands.subcommands?.find((s) => s.name === 'current');
+            if (currentSubcommand) {
+                return currentSubcommand.handler([], agent);
+            }
+            return true;
+        }
+
+        const subcommand = args[0];
+        const subArgs = args.slice(1);
+
+        // Find matching subcommand
+        const subcmd = modelCommands.subcommands?.find((s) => s.name === subcommand);
+        if (subcmd) {
+            return subcmd.handler(subArgs, agent);
+        }
+
+        console.log(chalk.red(`❌ Unknown model subcommand: ${subcommand}`));
+        console.log(chalk.dim('Available subcommands: current, switch'));
+        return true;
+    },
+};
+
+/**
+ * All available CLI commands
+ */
+export const CLI_COMMANDS: CommandDefinition[] = [
+    {
+        name: 'help',
+        description: 'Show help information',
+        usage: '/help [command]',
+        aliases: ['h', '?'],
+        handler: async (args: string[], _agent: SaikiAgent) => {
+            if (args.length === 0) {
+                displayAllCommands(CLI_COMMANDS);
+                return true;
+            }
+
+            const commandName = args[0];
+            if (!commandName) {
+                console.log(chalk.red('❌ No command specified'));
+                return true;
+            }
+
+            const command = CLI_COMMANDS.find(
+                (c) => c.name === commandName || (c.aliases && c.aliases.includes(commandName))
+            );
+
+            if (command) {
+                console.log('\n' + formatCommandHelp(command, true) + '\n');
+            } else {
+                console.log(chalk.red(`❌ Unknown command: ${commandName}`));
+                console.log(chalk.dim('Use /help to see all available commands'));
+            }
+            return true;
+        },
+    },
+    {
+        name: 'exit',
+        description: 'Exit the CLI',
+        usage: '/exit',
+        aliases: ['quit', 'q'],
+        handler: async (_args: string[], _agent: SaikiAgent) => {
+            logger.warn('Exiting AI CLI. Goodbye!');
+            process.exit(0);
+        },
+    },
+    {
+        name: 'clear',
+        description: 'Clear conversation history',
+        usage: '/clear',
+        aliases: ['reset'],
+        handler: async (_args: string[], agent: SaikiAgent) => {
+            try {
+                await agent.resetConversation();
+                logger.info('🔄 Conversation history cleared.', null, 'green');
+            } catch (error) {
+                logger.error(
+                    `Failed to clear conversation: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+            return true;
+        },
+    },
+    {
+        name: 'history',
+        description: 'Show conversation history',
+        usage: '/history [sessionId]',
+        aliases: ['hist'],
+        handler: async (args: string[], agent: SaikiAgent) => {
+            try {
+                // Use provided session ID or current session
+                const sessionId =
+                    args.length > 0 && args[0] ? args[0] : agent.getCurrentSessionId();
+
+                console.log(
+                    chalk.blue(`\n💬 Conversation History for: ${chalk.bold(sessionId)}\n`)
+                );
+
+                const history = await agent.getSessionHistory(sessionId);
+
+                if (history.length === 0) {
+                    console.log(chalk.dim('  No messages in this conversation yet.\n'));
+                    return true;
+                }
+
+                // Display each message with formatting
+                history.forEach((message, index) => {
+                    console.log(formatHistoryMessage(message, index));
+                });
+
+                console.log(chalk.dim(`\n  Total: ${history.length} messages`));
+                console.log(
+                    chalk.dim(
+                        '  💡 Use /clear to reset conversation or /session switch to change sessions\n'
+                    )
+                );
+            } catch (error) {
+                if (error instanceof Error && error.message.includes('not found')) {
+                    console.log(chalk.red(`❌ Session not found: ${args[0] || 'current'}`));
+                    console.log(chalk.dim('   Use /session list to see available sessions'));
+                } else {
+                    logger.error(
+                        `Failed to get session history: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+            }
+            return true;
+        },
+    },
+    sessionCommands,
+    modelCommands,
+    {
+        name: 'log',
+        description: `Set or view log level. Available levels: ${chalk.cyan('error')}, ${chalk.cyan('warn')}, ${chalk.cyan('info')}, ${chalk.cyan('debug')}, ${chalk.cyan('verbose')}.`,
+        usage: '/log [level]',
+        aliases: [],
+        handler: async (args: string[], _agent: SaikiAgent) => {
+            const validLevels = ['error', 'warn', 'info', 'debug', 'verbose'];
+            const level = args[0];
+
+            if (!level) {
+                console.log(chalk.blue(`\nCurrent log level: ${chalk.cyan(logger.getLevel())}`));
+                console.log(chalk.dim('Available levels: error, warn, info, debug, verbose'));
+                return true;
+            }
+
+            if (validLevels.includes(level)) {
+                logger.setLevel(level as any);
+                logger.info(`Log level set to ${level}`, null, 'green');
+            } else {
+                logger.error(
+                    `Invalid log level: ${level}. Valid levels are: ${validLevels.join(', ')}`
+                );
+            }
+            return true;
+        },
+    },
+    {
+        name: 'config',
+        description: 'Show current configuration',
+        usage: '/config',
+        handler: async (_args: string[], agent: SaikiAgent) => {
+            try {
+                const config = agent.getEffectiveConfig();
+                console.log(chalk.blue('\n⚙️  Current Configuration:\n'));
+
+                // LLM Config
+                console.log(chalk.bold('🤖 LLM:'));
+                console.log(`  Provider: ${chalk.cyan(config.llm.provider)}`);
+                console.log(`  Model: ${chalk.cyan(config.llm.model)}`);
+                console.log(`  Router: ${chalk.cyan(config.llm.router)}`);
+
+                // Session Config
+                console.log(chalk.bold('\n💬 Sessions:'));
+                console.log(
+                    `  Max Sessions: ${chalk.cyan(config.sessions?.maxSessions?.toString() || 'Default')}`
+                );
+                console.log(
+                    `  Session TTL: ${chalk.cyan(config.sessions?.sessionTTL ? `${config.sessions.sessionTTL / 1000}s` : 'Default')}`
+                );
+
+                // MCP Servers
+                console.log(chalk.bold('\n🔌 MCP Servers:'));
+                const servers = Object.keys(config.mcpServers || {});
+                if (servers.length > 0) {
+                    for (const server of servers) {
+                        console.log(`  ${chalk.cyan(server)}`);
+                    }
+                } else {
+                    console.log(chalk.dim('  No MCP servers configured'));
+                }
+
+                console.log();
+            } catch (error) {
+                logger.error(
+                    `Failed to get configuration: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+            return true;
+        },
+    },
+    {
+        name: 'stats',
+        description: 'Show system statistics',
+        usage: '/stats',
+        handler: async (_args: string[], agent: SaikiAgent) => {
+            try {
+                console.log(chalk.blue('\n📊 System Statistics:\n'));
+
+                // Session stats
+                const sessionStats = await agent.sessionManager.getSessionStats();
+                console.log(chalk.bold('💬 Sessions:'));
+                console.log(
+                    `  Total Sessions: ${chalk.cyan(sessionStats.totalSessions.toString())}`
+                );
+                console.log(`  In Memory: ${chalk.cyan(sessionStats.inMemorySessions.toString())}`);
+                console.log(`  Max Allowed: ${chalk.cyan(sessionStats.maxSessions.toString())}`);
+
+                // MCP stats
+                console.log(chalk.bold('\n🔌 MCP Servers:'));
+                const connectedServers = agent.mcpManager.getClients().size;
+                const failedConnections = Object.keys(
+                    agent.mcpManager.getFailedConnections()
+                ).length;
+                console.log(`  Connected: ${chalk.green(connectedServers.toString())}`);
+                if (failedConnections > 0) {
+                    console.log(`  Failed: ${chalk.red(failedConnections.toString())}`);
+                }
+
+                // Tools
+                try {
+                    const tools = await agent.mcpManager.getAllTools();
+                    console.log(
+                        `  Available Tools: ${chalk.cyan(Object.keys(tools).length.toString())}`
+                    );
+                } catch {
+                    console.log(`  Available Tools: ${chalk.dim('Unable to count')}`);
+                }
+
+                console.log();
+            } catch (error) {
+                logger.error(
+                    `Failed to get statistics: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+            return true;
+        },
+    },
+];
+
+/**
+ * Execute a slash command
+ */
+export async function executeCommand(
+    command: string,
+    args: string[],
+    agent: SaikiAgent
+): Promise<boolean> {
+    // Find the command (including aliases)
+    const cmd = CLI_COMMANDS.find(
+        (c) => c.name === command || (c.aliases && c.aliases.includes(command))
+    );
+
+    if (!cmd) {
+        console.log(chalk.red(`❌ Unknown command: /${command}`));
+        console.log(chalk.dim('Type /help to see available commands'));
+        return true;
+    }
+
+    try {
+        return await cmd.handler(args, agent);
+    } catch (error) {
+        logger.error(
+            `Command execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        return true;
+    }
+}

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -218,7 +218,7 @@ const sessionCommands: CommandDefinition = {
                 }
 
                 try {
-                    const sessionId = args[0];
+                    const sessionId = args[0]!; // Safe to assert non-null since we checked args.length
 
                     await agent.loadSession(sessionId);
 
@@ -313,7 +313,7 @@ const sessionCommands: CommandDefinition = {
                 }
 
                 try {
-                    const sessionId = args[0];
+                    const sessionId = args[0]!; // Safe to assert non-null since we checked args.length
 
                     const current = await getCurrentSessionInfo(agent);
 

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -1,3 +1,44 @@
+/**
+ * CLI Commands Module
+ *
+ * This module defines all available slash commands for the Saiki CLI interface.
+ * Commands provide system control and agent management functionality.
+ *
+ * Available Commands:
+ *
+ * GENERAL:
+ * - /help [command] - Show help information for all commands or a specific command
+ * - /exit, /quit, /q - Exit the CLI application
+ * - /clear, /reset - Clear conversation history for current session
+ * - /history [sessionId], /hist - Show conversation history (current or specified session)
+ *
+ * SESSION MANAGEMENT:
+ * - /session, /s - Manage chat sessions (defaults to list)
+ *   - /session list - List all available sessions with metadata
+ *   - /session new [id] - Create a new session with optional custom ID
+ *   - /session switch <id> - Switch to a different session
+ *   - /session current - Show current active session info
+ *   - /session history [id], /session h - Show conversation history
+ *   - /session delete <id> - Delete a session (cannot delete active session)
+ *
+ * MODEL MANAGEMENT:
+ * - /model, /m - Manage AI models (defaults to current)
+ *   - /model current - Show current model configuration
+ *   - /model switch <model> [provider] - Switch to a different model/provider
+ *
+ * SYSTEM CONFIGURATION:
+ * - /log [level] - Set or view current log level
+ *   Available levels: error, warn, info, http, verbose, debug, silly
+ * - /config - Show current agent configuration (LLM, sessions, MCP servers)
+ * - /stats - Show system statistics (sessions, MCP servers, tools)
+ *
+ * Usage:
+ * - Commands start with '/' followed by the command name
+ * - Arguments are space-separated
+ * - Commands with subcommands default to a primary action if no subcommand given
+ * - Use /help <command> for detailed help on specific commands
+ */
+
 import chalk from 'chalk';
 import { logger } from '@core/index.js';
 import { SaikiAgent } from '@core/index.js';

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -79,6 +79,30 @@ async function getCurrentSessionInfo(agent: SaikiAgent): Promise<{ id: string; m
 }
 
 /**
+ * Helper to display session history with consistent formatting
+ */
+async function displaySessionHistory(sessionId: string, agent: SaikiAgent): Promise<void> {
+    console.log(chalk.blue(`\n💬 Conversation History for: ${chalk.bold(sessionId)}\n`));
+
+    const history = await agent.getSessionHistory(sessionId);
+
+    if (history.length === 0) {
+        console.log(chalk.dim('  No messages in this conversation yet.\n'));
+        return;
+    }
+
+    // Display each message with formatting
+    history.forEach((message, index) => {
+        console.log(formatHistoryMessage(message, index));
+    });
+
+    console.log(chalk.dim(`\n  Total: ${history.length} messages`));
+    console.log(
+        chalk.dim('  💡 Use /clear to reset conversation or /session switch to change sessions\n')
+    );
+}
+
+/**
  * Helper to format conversation history
  */
 function formatHistoryMessage(message: any, index: number): string {
@@ -267,28 +291,7 @@ const sessionCommands: CommandDefinition = {
                     const sessionId =
                         args.length > 0 && args[0] ? args[0] : agent.getCurrentSessionId();
 
-                    console.log(
-                        chalk.blue(`\n💬 Conversation History for: ${chalk.bold(sessionId)}\n`)
-                    );
-
-                    const history = await agent.getSessionHistory(sessionId);
-
-                    if (history.length === 0) {
-                        console.log(chalk.dim('  No messages in this conversation yet.\n'));
-                        return true;
-                    }
-
-                    // Display each message with formatting
-                    history.forEach((message, index) => {
-                        console.log(formatHistoryMessage(message, index));
-                    });
-
-                    console.log(chalk.dim(`\n  Total: ${history.length} messages`));
-                    console.log(
-                        chalk.dim(
-                            '  💡 Use /clear to reset conversation or /session switch to change sessions\n'
-                        )
-                    );
+                    await displaySessionHistory(sessionId, agent);
                 } catch (error) {
                     if (error instanceof Error && error.message.includes('not found')) {
                         console.log(chalk.red(`❌ Session not found: ${args[0] || 'current'}`));
@@ -559,28 +562,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
                 const sessionId =
                     args.length > 0 && args[0] ? args[0] : agent.getCurrentSessionId();
 
-                console.log(
-                    chalk.blue(`\n💬 Conversation History for: ${chalk.bold(sessionId)}\n`)
-                );
-
-                const history = await agent.getSessionHistory(sessionId);
-
-                if (history.length === 0) {
-                    console.log(chalk.dim('  No messages in this conversation yet.\n'));
-                    return true;
-                }
-
-                // Display each message with formatting
-                history.forEach((message, index) => {
-                    console.log(formatHistoryMessage(message, index));
-                });
-
-                console.log(chalk.dim(`\n  Total: ${history.length} messages`));
-                console.log(
-                    chalk.dim(
-                        '  💡 Use /clear to reset conversation or /session switch to change sessions\n'
-                    )
-                );
+                await displaySessionHistory(sessionId, agent);
             } catch (error) {
                 if (error instanceof Error && error.message.includes('not found')) {
                     console.log(chalk.red(`❌ Session not found: ${args[0] || 'current'}`));

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -219,12 +219,6 @@ const sessionCommands: CommandDefinition = {
 
                 try {
                     const sessionId = args[0];
-                    if (!sessionId) {
-                        console.log(
-                            chalk.red('❌ Session ID required. Usage: /session switch <id>')
-                        );
-                        return true;
-                    }
 
                     await agent.loadSession(sessionId);
 
@@ -320,12 +314,6 @@ const sessionCommands: CommandDefinition = {
 
                 try {
                     const sessionId = args[0];
-                    if (!sessionId) {
-                        console.log(
-                            chalk.red('❌ Session ID required. Usage: /session delete <id>')
-                        );
-                        return true;
-                    }
 
                     const current = await getCurrentSessionInfo(agent);
 

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -569,16 +569,18 @@ export const CLI_COMMANDS: CommandDefinition[] = [
     modelCommands,
     {
         name: 'log',
-        description: `Set or view log level. Available levels: ${chalk.cyan('error')}, ${chalk.cyan('warn')}, ${chalk.cyan('info')}, ${chalk.cyan('debug')}, ${chalk.cyan('verbose')}.`,
+        description: `Set or view log level. Available levels: ${chalk.cyan('error')}, ${chalk.cyan('warn')}, ${chalk.cyan('info')}, ${chalk.cyan('http')}, ${chalk.cyan('verbose')}, ${chalk.cyan('debug')}, ${chalk.cyan('silly')}.`,
         usage: '/log [level]',
         aliases: [],
         handler: async (args: string[], _agent: SaikiAgent) => {
-            const validLevels = ['error', 'warn', 'info', 'debug', 'verbose'];
+            const validLevels = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
             const level = args[0];
 
             if (!level) {
                 console.log(chalk.blue(`\nCurrent log level: ${chalk.cyan(logger.getLevel())}`));
-                console.log(chalk.dim('Available levels: error, warn, info, debug, verbose'));
+                console.log(
+                    chalk.dim('Available levels: error, warn, info, http, verbose, debug, silly')
+                );
                 return true;
             }
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -54,6 +54,7 @@ program
     .option('--no-verbose', 'Disable verbose output')
     .option('-m, --model <model>', 'Specify the LLM model to use. ')
     .option('-r, --router <router>', 'Specify the LLM router to use (vercel or in-built)')
+    .option('--new-session [sessionId]', 'Start with a new session (optionally specify session ID)')
     .option(
         '--mode <mode>',
         'The application in which saiki should talk to you - cli | web | server | discord | telegram | mcp',
@@ -145,7 +146,7 @@ program
         '--group-servers',
         'Aggregate and re-expose tools from configured MCP servers (required for now)'
     )
-    .option('--name <name>', 'Name for the MCP server', 'saiki-tools')
+    .option('--name <n>', 'Name for the MCP server', 'saiki-tools')
     .option('--version <version>', 'Version for the MCP server', '1.0.0')
     .action(async (options) => {
         try {
@@ -221,6 +222,7 @@ program
             'build complex AI applications like Cursor, and more.\n\n' +
             // TODO: Add `saiki tell me about your cli` starter prompt
             'Run saiki interactive CLI with `saiki` or run a one-shot prompt with `saiki <prompt>`\n' +
+            'Start with a new session using `saiki --new-session [sessionId]`\n' +
             'Run saiki web UI with `saiki --mode web`\n' +
             'Run saiki as a server (REST APIs + WebSockets) with `saiki --mode server`\n' +
             'Run saiki as a discord bot with `saiki --mode discord`\n' +
@@ -308,6 +310,27 @@ program
 
             // Start the agent (initialize async services)
             await agent.start();
+
+            // Handle --new-session flag
+            if (opts.newSession !== undefined) {
+                try {
+                    // Use provided session ID or generate a random one
+                    const sessionId =
+                        typeof opts.newSession === 'string' && opts.newSession
+                            ? opts.newSession
+                            : undefined; // Let agent generate random ID
+
+                    const session = await agent.createSession(sessionId);
+                    await agent.loadSession(session.id);
+
+                    logger.info(`Created and loaded new session: ${session.id}`, null, 'green');
+                } catch (err) {
+                    logger.error(
+                        `Failed to create new session: ${err instanceof Error ? err.message : String(err)}`
+                    );
+                    process.exit(1);
+                }
+            }
         } catch (err) {
             logger.error((err as Error).message);
             process.exit(1);


### PR DESCRIPTION
`help` commands in the CLI are now replaced with slash commands. 
Additionally, some supporting slash commands have been added for session management as an initial implementation for better interactive lifecycle management of chats.

<img width="1504" alt="Screenshot 2025-07-01 at 3 22 25 PM" src="https://github.com/user-attachments/assets/c0cc23af-e7c7-4196-943d-7b092b76382d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now automatically loads the most recent session based on activity.
  * Added structured slash command support for session and model management, system stats, help, and more.
  * Introduced a new command-line option to start a new session with an optional session ID.

* **Improvements**
  * Enhanced input parsing to better distinguish commands from prompts.
  * Improved CLI guidance with clearer welcome and help messages.
  * Added autocomplete suggestions and colorized output for commands and help.

* **Bug Fixes**
  * Improved error handling and user feedback when managing sessions or switching models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->