### PR TITLE
Cli improvements

### DIFF
--- a/src/app/cli/cli.ts
+++ b/src/app/cli/cli.ts
@@ -36,7 +36,7 @@ async function loadMostRecentSession(agent: SaikiAgent): Promise<void> {
         const currentSessionId = agent.getCurrentSessionId();
         if (mostRecentSession !== currentSessionId) {
             await agent.loadSession(mostRecentSession);
-            logger.debug(`Loaded most recent session: ${mostRecentSession}`);
+            logger.info(`Loaded session: ${mostRecentSession}`, null, 'cyan');
         }
     } catch (error) {
         // If anything fails, just continue with current session
@@ -51,7 +51,6 @@ async function loadMostRecentSession(agent: SaikiAgent): Promise<void> {
  * @param agent The SaikiAgent instance providing access to all required services
  */
 async function _initCli(agent: SaikiAgent): Promise<void> {
-    // Load the most recent session instead of always using 'default'
     await loadMostRecentSession(agent);
 
     // Log connection info
@@ -84,31 +83,6 @@ async function _initCli(agent: SaikiAgent): Promise<void> {
             `Failed to load tools: ${error instanceof Error ? error.message : String(error)}`
         );
     }
-
-    // Determine which session will be used and whether it already has history
-    const currentSessionId = agent.getCurrentSessionId();
-    let conversationState = 'Starting new conversation';
-    let messageCount = 0;
-    try {
-        const metadata = await agent.getSessionMetadata(currentSessionId);
-        if (metadata) {
-            messageCount = metadata.messageCount;
-            if (messageCount > 0) {
-                conversationState = 'Resuming existing conversation';
-            }
-        }
-    } catch (error) {
-        // Non-fatal – fall back to default state
-        logger.debug(
-            `Failed to retrieve session metadata for ${currentSessionId}: ${error instanceof Error ? error.message : String(error)}`
-        );
-    }
-
-    logger.info(
-        `Loading session '${currentSessionId}'. ${conversationState} (${messageCount} messages).`,
-        null,
-        messageCount > 0 ? 'yellow' : 'green'
-    );
 
     logger.info(`CLI initialized successfully. Ready for input.`, null, 'green');
 

--- a/src/app/cli/command-parser.ts
+++ b/src/app/cli/command-parser.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk';
+import type { SaikiAgent } from '@core/index.js';
 
 export interface CommandResult {
     type: 'command' | 'prompt';
     command?: string;
     args?: string[];
-    rawInput?: string;
+    rawInput: string;
 }
 
 export interface CommandDefinition {
@@ -13,7 +14,7 @@ export interface CommandDefinition {
     usage: string;
     aliases?: string[];
     subcommands?: CommandDefinition[];
-    handler: (args: string[], agent: any) => Promise<boolean>;
+    handler: (args: string[], agent: SaikiAgent) => Promise<boolean>;
 }
 
 /**
@@ -114,7 +115,7 @@ export function displayAllCommands(commands: CommandDefinition[]): void {
             categories['Session Management']!.push(cmd);
         } else if (cmd.name.startsWith('model')) {
             categories['Model Management']!.push(cmd);
-        } else if (['config', 'stats', 'log'].includes(cmd.name)) {
+        } else if (['config', 'stats', 'log', 'tools', 'prompt'].includes(cmd.name)) {
             categories['System']!.push(cmd);
         } else {
             categories['General']!.push(cmd);

--- a/src/app/cli/command-parser.ts
+++ b/src/app/cli/command-parser.ts
@@ -12,6 +12,7 @@ export interface CommandDefinition {
     name: string;
     description: string;
     usage: string;
+    category?: string;
     aliases?: string[];
     subcommands?: CommandDefinition[];
     handler: (args: string[], agent: SaikiAgent) => Promise<boolean>;
@@ -102,29 +103,47 @@ export function formatCommandHelp(cmd: CommandDefinition, detailed: boolean = fa
 export function displayAllCommands(commands: CommandDefinition[]): void {
     console.log(chalk.bold.green('\n📋 Available Commands:\n'));
 
-    const categories: { [key: string]: CommandDefinition[] } = {
-        'Session Management': [],
-        'Model Management': [],
-        System: [],
-        General: [],
-    };
+    // Define category order for consistent display
+    const categoryOrder = [
+        'General',
+        'Session Management',
+        'Model Management',
+        'Tool Management',
+        'Prompt Management',
+        'System',
+    ];
 
-    // Categorize commands
+    const categories: { [key: string]: CommandDefinition[] } = {};
+
+    // Initialize categories
+    for (const category of categoryOrder) {
+        categories[category] = [];
+    }
+
+    // Categorize commands using metadata
     for (const cmd of commands) {
-        if (cmd.name.startsWith('session')) {
-            categories['Session Management']!.push(cmd);
-        } else if (cmd.name.startsWith('model')) {
-            categories['Model Management']!.push(cmd);
-        } else if (['config', 'stats', 'log', 'tools', 'prompt'].includes(cmd.name)) {
-            categories['System']!.push(cmd);
-        } else {
-            categories['General']!.push(cmd);
+        const category = cmd.category || 'General';
+        if (!categories[category]) {
+            categories[category] = [];
+        }
+        categories[category]!.push(cmd);
+    }
+
+    // Display by category in order
+    for (const category of categoryOrder) {
+        const cmds = categories[category];
+        if (cmds && cmds.length > 0) {
+            console.log(chalk.bold.yellow(`${category}:`));
+            for (const cmd of cmds) {
+                console.log('  ' + formatCommandHelp(cmd));
+            }
+            console.log();
         }
     }
 
-    // Display by category
+    // Display any uncategorized commands (fallback)
     for (const [category, cmds] of Object.entries(categories)) {
-        if (cmds.length > 0) {
+        if (!categoryOrder.includes(category) && cmds.length > 0) {
             console.log(chalk.bold.yellow(`${category}:`));
             for (const cmd of cmds) {
                 console.log('  ' + formatCommandHelp(cmd));

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -23,8 +23,9 @@
  *   - /session delete <id> - Delete a session (cannot delete active session)
  *
  * MODEL MANAGEMENT:
- * - /model, /m - Manage AI models (defaults to current)
+ * - /model, /m - Manage AI models (defaults to help)
  *   - /model help - Show detailed help for model commands
+ *   - /model list - List all supported providers and models
  *   - /model current - Show current model configuration
  *   - /model switch <model> [provider] - Switch to a different model/provider
  *
@@ -435,6 +436,47 @@ const modelCommands: CommandDefinition = {
     aliases: ['m'],
     subcommands: [
         {
+            name: 'list',
+            description: 'List all supported providers and models',
+            usage: '/model list',
+            handler: async (_args: string[], agent: SaikiAgent) => {
+                try {
+                    console.log(chalk.bold.blue('\n🤖 Supported Models and Providers:\n'));
+
+                    const providers = agent.getSupportedProviders();
+                    const allModels = agent.getSupportedModels();
+
+                    for (const provider of providers) {
+                        const models = allModels[provider];
+
+                        console.log(chalk.bold.yellow(`${provider.toUpperCase()}:`));
+                        console.log(chalk.cyan('  Models:'));
+
+                        for (const model of models) {
+                            const tokenLimit = ` (${model.maxInputTokens.toLocaleString()} tokens)`;
+                            const defaultLabel = model.isDefault ? chalk.green(' [DEFAULT]') : '';
+
+                            console.log(
+                                `    ${chalk.cyan(model.name)}${tokenLimit}${defaultLabel}`
+                            );
+                        }
+                        console.log();
+                    }
+
+                    console.log(
+                        chalk.dim('💡 Use /model switch <provider> <model> to switch models')
+                    );
+                    console.log(chalk.dim('💡 Default models are marked with [DEFAULT]'));
+                    console.log(chalk.dim('💡 Token limits show maximum input context size\n'));
+                } catch (error) {
+                    logger.error(
+                        `Failed to list models: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+                return true;
+            },
+        },
+        {
             name: 'current',
             description: 'Show current model configuration',
             usage: '/model current',
@@ -529,6 +571,9 @@ const modelCommands: CommandDefinition = {
 
                 console.log(chalk.cyan('Available subcommands:'));
                 console.log(
+                    `  ${chalk.yellow('/model list')} - List all supported providers, models, and capabilities`
+                );
+                console.log(
                     `  ${chalk.yellow('/model current')} - Display currently active model and configuration`
                 );
                 console.log(
@@ -537,9 +582,9 @@ const modelCommands: CommandDefinition = {
                 console.log(`        Examples:`);
                 console.log(`          ${chalk.dim('/model switch openai gpt-4o')}`);
                 console.log(
-                    `          ${chalk.dim('/model switch anthropic claude-3-5-sonnet-20241022')}`
+                    `          ${chalk.dim('/model switch anthropic claude-4-sonnet-20250514')}`
                 );
-                console.log(`          ${chalk.dim('/model switch google gemini-2.0-flash-exp')}`);
+                console.log(`          ${chalk.dim('/model switch google gemini-2.5-pro')}`);
                 console.log(`  ${chalk.yellow('/model help')} - Show this help message`);
 
                 console.log(
@@ -573,7 +618,7 @@ const modelCommands: CommandDefinition = {
         }
 
         console.log(chalk.red(`❌ Unknown model subcommand: ${subcommand}`));
-        console.log(chalk.dim('Available subcommands: current, switch, help'));
+        console.log(chalk.dim('Available subcommands: list, current, switch, help'));
         console.log(chalk.dim('💡 Use /model help for detailed command descriptions'));
         return true;
     },

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -7,13 +7,14 @@
  * Available Commands:
  *
  * GENERAL:
- * - /help [command] - Show help information for all commands or a specific command
+ * - /help [command] - Show help information (redirects to contextual help for major commands)
  * - /exit, /quit, /q - Exit the CLI application
  * - /clear, /reset - Clear conversation history for current session
  * - /history [sessionId], /hist - Show conversation history (current or specified session)
  *
  * SESSION MANAGEMENT:
- * - /session, /s - Manage chat sessions (defaults to list)
+ * - /session, /s - Manage chat sessions (defaults to help)
+ *   - /session help - Show detailed help for session commands
  *   - /session list - List all available sessions with metadata
  *   - /session new [id] - Create a new session with optional custom ID
  *   - /session switch <id> - Switch to a different session
@@ -23,6 +24,7 @@
  *
  * MODEL MANAGEMENT:
  * - /model, /m - Manage AI models (defaults to current)
+ *   - /model help - Show detailed help for model commands
  *   - /model current - Show current model configuration
  *   - /model switch <model> [provider] - Switch to a different model/provider
  *
@@ -32,11 +34,18 @@
  * - /config - Show current agent configuration (LLM, sessions, MCP servers)
  * - /stats - Show system statistics (sessions, MCP servers, tools)
  *
+ * TOOL MANAGEMENT:
+ * - /tools - List all available MCP tools with descriptions
+ *
+ * PROMPT MANAGEMENT
+ * - /prompt - Display the current system prompt
+ *
  * Usage:
  * - Commands start with '/' followed by the command name
  * - Arguments are space-separated
  * - Commands with subcommands default to a primary action if no subcommand given
- * - Use /help <command> for detailed help on specific commands
+ * - Use contextual help for detailed guidance (e.g., /session help, /model help)
+ * - /help redirects to contextual help for major command groups
  */
 
 import chalk from 'chalk';
@@ -180,6 +189,7 @@ const sessionCommands: CommandDefinition = {
     name: 'session',
     description: 'Manage chat sessions',
     usage: '/session <subcommand> [args]',
+    category: 'Session Management',
     aliases: ['s'],
     subcommands: [
         {
@@ -357,22 +367,24 @@ const sessionCommands: CommandDefinition = {
 
                 console.log(chalk.cyan('Available subcommands:'));
                 console.log(
-                    `  ${chalk.yellow('list')} - List all sessions with their status and activity`
+                    `  ${chalk.yellow('/session list')} - List all sessions with their status and activity`
                 );
                 console.log(
-                    `  ${chalk.yellow('new')} [name] - Create a new session (optional custom name)`
-                );
-                console.log(`  ${chalk.yellow('switch')} <id> - Switch to a different session`);
-                console.log(
-                    `  ${chalk.yellow('current')} - Show current session info and message count`
+                    `  ${chalk.yellow('/session new')} ${chalk.blue('[name]')} - Create a new session (optional custom name)`
                 );
                 console.log(
-                    `  ${chalk.yellow('history')} - Display conversation history for current session`
+                    `  ${chalk.yellow('/session switch')} ${chalk.blue('<id>')} - Switch to a different session`
                 );
                 console.log(
-                    `  ${chalk.yellow('delete')} <id> - Delete a session (cannot delete active session)`
+                    `  ${chalk.yellow('/session current')} - Show current session info and message count`
                 );
-                console.log(`  ${chalk.yellow('help')} - Show this help message`);
+                console.log(
+                    `  ${chalk.yellow('/session history')} - Display conversation history for current session`
+                );
+                console.log(
+                    `  ${chalk.yellow('/session delete')} ${chalk.blue('<id>')} - Delete a session (cannot delete active session)`
+                );
+                console.log(`  ${chalk.yellow('/session help')} - Show this help message`);
 
                 console.log(
                     chalk.dim('\n💡 Sessions allow you to maintain separate conversations')
@@ -385,11 +397,11 @@ const sessionCommands: CommandDefinition = {
         },
     ],
     handler: async (args: string[], agent: SaikiAgent) => {
-        // Default to list if no subcommand
+        // Default to help if no subcommand
         if (args.length === 0) {
-            const listSubcommand = sessionCommands.subcommands?.find((s) => s.name === 'list');
-            if (listSubcommand) {
-                return listSubcommand.handler([], agent);
+            const helpSubcommand = sessionCommands.subcommands?.find((s) => s.name === 'help');
+            if (helpSubcommand) {
+                return helpSubcommand.handler([], agent);
             }
             return true;
         }
@@ -419,6 +431,7 @@ const modelCommands: CommandDefinition = {
     name: 'model',
     description: 'Manage AI models',
     usage: '/model <subcommand> [args]',
+    category: 'Model Management',
     aliases: ['m'],
     subcommands: [
         {
@@ -465,8 +478,8 @@ const modelCommands: CommandDefinition = {
                 }
 
                 try {
-                    const model = args[0];
-                    const provider = args[1];
+                    const provider = args[0];
+                    const model = args[1];
 
                     console.log(
                         chalk.yellow(
@@ -516,18 +529,18 @@ const modelCommands: CommandDefinition = {
 
                 console.log(chalk.cyan('Available subcommands:'));
                 console.log(
-                    `  ${chalk.yellow('current')} - Display currently active model and configuration`
+                    `  ${chalk.yellow('/model current')} - Display currently active model and configuration`
                 );
                 console.log(
-                    `  ${chalk.yellow('switch')} <provider> <model> - Switch to a different AI model`
+                    `  ${chalk.yellow('/model switch')} ${chalk.blue('<provider> <model>')} - Switch to a different AI model`
                 );
                 console.log(`        Examples:`);
                 console.log(`          ${chalk.dim('/model switch openai gpt-4o')}`);
                 console.log(
                     `          ${chalk.dim('/model switch anthropic claude-3-5-sonnet-20241022')}`
                 );
-                console.log(`          ${chalk.dim('/model switch gemini gemini-2.0-flash-exp')}`);
-                console.log(`  ${chalk.yellow('help')} - Show this help message`);
+                console.log(`          ${chalk.dim('/model switch google gemini-2.0-flash-exp')}`);
+                console.log(`  ${chalk.yellow('/model help')} - Show this help message`);
 
                 console.log(
                     chalk.dim('\n💡 Switching models allows you to use different AI capabilities')
@@ -541,11 +554,11 @@ const modelCommands: CommandDefinition = {
         },
     ],
     handler: async (args: string[], agent: SaikiAgent) => {
-        // Default to current if no subcommand
+        // Default to help if no subcommand
         if (args.length === 0) {
-            const currentSubcommand = modelCommands.subcommands?.find((s) => s.name === 'current');
-            if (currentSubcommand) {
-                return currentSubcommand.handler([], agent);
+            const helpSubcommand = modelCommands.subcommands?.find((s) => s.name === 'help');
+            if (helpSubcommand) {
+                return helpSubcommand.handler([], agent);
             }
             return true;
         }
@@ -574,6 +587,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'help',
         description: 'Show help information',
         usage: '/help [command]',
+        category: 'General',
         aliases: ['h', '?'],
         handler: async (args: string[], _agent: SaikiAgent) => {
             if (args.length === 0) {
@@ -584,6 +598,25 @@ export const CLI_COMMANDS: CommandDefinition[] = [
             const commandName = args[0];
             if (!commandName) {
                 console.log(chalk.red('❌ No command specified'));
+                return true;
+            }
+
+            // Redirect to contextual help for commands that have their own help subcommands
+            if (commandName === 'session' || commandName === 's') {
+                console.log(chalk.blue('💡 For detailed session help, use:'));
+                console.log(`   ${chalk.cyan('/session help')}`);
+                console.log(
+                    chalk.dim('\n   This shows all session subcommands with examples and tips.')
+                );
+                return true;
+            }
+
+            if (commandName === 'model' || commandName === 'm') {
+                console.log(chalk.blue('💡 For detailed model help, use:'));
+                console.log(`   ${chalk.cyan('/model help')}`);
+                console.log(
+                    chalk.dim('\n   This shows all model subcommands with examples and usage.')
+                );
                 return true;
             }
 
@@ -604,6 +637,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'exit',
         description: 'Exit the CLI',
         usage: '/exit',
+        category: 'General',
         aliases: ['quit', 'q'],
         handler: async (_args: string[], _agent: SaikiAgent) => {
             logger.warn('Exiting AI CLI. Goodbye!');
@@ -614,6 +648,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'clear',
         description: 'Clear conversation history',
         usage: '/clear',
+        category: 'General',
         aliases: ['reset'],
         handler: async (_args: string[], agent: SaikiAgent) => {
             try {
@@ -631,6 +666,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'history',
         description: 'Show conversation history',
         usage: '/history [sessionId]',
+        category: 'General',
         aliases: ['hist'],
         handler: async (args: string[], agent: SaikiAgent) => {
             try {
@@ -658,6 +694,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'log',
         description: `Set or view log level. Available levels: ${chalk.cyan('error')}, ${chalk.cyan('warn')}, ${chalk.cyan('info')}, ${chalk.cyan('http')}, ${chalk.cyan('verbose')}, ${chalk.cyan('debug')}, ${chalk.cyan('silly')}.`,
         usage: '/log [level]',
+        category: 'System',
         aliases: [],
         handler: async (args: string[], _agent: SaikiAgent) => {
             const validLevels = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
@@ -668,6 +705,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
                 console.log(
                     chalk.dim('Available levels: error, warn, info, http, verbose, debug, silly')
                 );
+                console.log(chalk.dim('💡 Use /log [level] to set the log level'));
                 return true;
             }
 
@@ -686,6 +724,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'config',
         description: 'Show current configuration',
         usage: '/config',
+        category: 'System',
         handler: async (_args: string[], agent: SaikiAgent) => {
             try {
                 const config = agent.getEffectiveConfig();
@@ -730,6 +769,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'stats',
         description: 'Show system statistics',
         usage: '/stats',
+        category: 'System',
         handler: async (_args: string[], agent: SaikiAgent) => {
             try {
                 console.log(chalk.blue('\n📊 System Statistics:\n'));
@@ -777,6 +817,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'tools',
         description: 'List all available MCP tools',
         usage: '/tools',
+        category: 'Tool Management',
         handler: async (args: string[], agent: SaikiAgent): Promise<boolean> => {
             try {
                 const tools = await agent.getAllMcpTools();
@@ -808,6 +849,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         name: 'prompt',
         description: 'Display the current system prompt',
         usage: '/prompt',
+        category: 'Prompt Management',
         handler: async (args: string[], agent: SaikiAgent): Promise<boolean> => {
             try {
                 const systemPrompt = await agent.getSystemPrompt();

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -905,6 +905,42 @@ export const CLI_COMMANDS: CommandDefinition[] = [
             return true;
         },
     },
+    {
+        name: 'docs',
+        description: 'Open Saiki documentation in browser',
+        usage: '/docs',
+        category: 'Documentation',
+        aliases: ['doc'],
+        handler: async (_args: string[], _agent: SaikiAgent): Promise<boolean> => {
+            try {
+                const { spawn } = await import('child_process');
+                const url = 'https://truffle-ai.github.io/saiki/docs/category/getting-started/';
+
+                console.log(chalk.blue(`🌐 Opening Saiki documentation: ${url}`));
+
+                // Cross-platform browser opening
+                const command =
+                    process.platform === 'darwin'
+                        ? 'open'
+                        : process.platform === 'win32'
+                          ? 'start'
+                          : 'xdg-open';
+
+                spawn(command, [url], { detached: true, stdio: 'ignore' });
+                console.log(chalk.green('✅ Documentation opened in browser'));
+            } catch (error) {
+                logger.error(
+                    `Failed to open documentation: ${error instanceof Error ? error.message : String(error)}`
+                );
+                console.log(
+                    chalk.yellow(
+                        '💡 You can manually visit: https://truffle-ai.github.io/saiki/docs/category/getting-started/'
+                    )
+                );
+            }
+            return true;
+        },
+    },
 ];
 
 /**

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -779,7 +779,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         usage: '/tools',
         handler: async (args: string[], agent: SaikiAgent): Promise<boolean> => {
             try {
-                const tools = await agent.mcpManager.getAllTools();
+                const tools = await agent.getAllMcpTools();
                 const toolEntries = Object.entries(tools);
 
                 if (toolEntries.length === 0) {
@@ -810,11 +810,7 @@ export const CLI_COMMANDS: CommandDefinition[] = [
         usage: '/prompt',
         handler: async (args: string[], agent: SaikiAgent): Promise<boolean> => {
             try {
-                // Build the prompt with the required context
-                const context = {
-                    mcpManager: agent.mcpManager,
-                };
-                const systemPrompt = await agent.promptManager.build(context);
+                const systemPrompt = await agent.getSystemPrompt();
 
                 console.log(chalk.bold.green('\n📋 Current System Prompt:\n'));
                 console.log(chalk.dim('─'.repeat(80)));

--- a/src/core/ai/agent/SaikiAgent.ts
+++ b/src/core/ai/agent/SaikiAgent.ts
@@ -502,33 +502,21 @@ export class SaikiAgent {
     // ============= LLM MANAGEMENT =============
 
     /**
-     * Gets the current LLM configuration.
+     * Gets the current LLM configuration with all defaults applied.
      * @returns Current LLM configuration
-     *
-     * TODO: USER-FACING API DECISION NEEDED
-     * Should this return:
-     * 1. ValidatedLLMConfig (with all defaults applied, internal representation)
-     * 2. LLMConfig (input type, matches what users expect to see)
-     *
-     * Currently returning ValidatedLLMConfig for consistency with internal state,
-     * but this means required fields that were optional in input appear required.
      */
-    public getCurrentLLMConfig(): ValidatedLLMConfig {
+    public getCurrentLLMConfig(): LLMConfig {
         this.ensureStarted();
-        return structuredClone(this.stateManager.getLLMConfig());
+        return structuredClone(this.stateManager.getLLMConfig()) as LLMConfig;
     }
 
     /**
      * Switches the LLM service while preserving conversation history.
      * This is a comprehensive method that handles ALL validation, configuration building, and switching internally.
      *
-     * TODO: USER-FACING API DECISION NEEDED
-     * Current design:
+     * Design:
      * - Input: Partial<LLMConfig> (allows optional fields like maxIterations?, router?)
-     * - Output: ValidatedLLMConfig (internal representation with all defaults applied)
-     *
-     * Question: Should the returned 'config' be LLMConfig (input type) to match
-     * user expectations, or ValidatedLLMConfig (internal type) for accuracy?
+     * - Output: LLMConfig (user-friendly type with all defaults applied)
      *
      * Key features:
      * - Accepts partial LLM configuration object
@@ -564,7 +552,7 @@ export class SaikiAgent {
         sessionId?: string
     ): Promise<{
         success: boolean;
-        config?: ValidatedLLMConfig;
+        config?: LLMConfig;
         message?: string;
         warnings?: string[];
         errors?: Array<{
@@ -658,7 +646,7 @@ export class SaikiAgent {
         configWarnings: string[] = []
     ): Promise<{
         success: boolean;
-        config?: ValidatedLLMConfig;
+        config?: LLMConfig;
         message?: string;
         warnings?: string[];
         errors?: Array<{
@@ -720,7 +708,7 @@ export class SaikiAgent {
 
         return {
             success: true,
-            config: validatedConfig,
+            config: validatedConfig as LLMConfig,
             message: switchResult.message,
             ...(allWarnings.length > 0 && { warnings: allWarnings }),
         };

--- a/src/core/ai/agent/SaikiAgent.ts
+++ b/src/core/ai/agent/SaikiAgent.ts
@@ -61,8 +61,8 @@ const requiredServices: (keyof AgentServices)[] = [
  * // Process user messages
  * const response = await agent.run("Hello, how are you?");
  *
- * // Switch LLM models
- * await agent.switchLLM({ model: 'gpt-4o', provider: 'openai' });
+ * // Switch LLM models (provider inferred automatically)
+ * await agent.switchLLM({ model: 'gpt-4o' });
  *
  * // Manage sessions
  * const session = agent.createSession('user-123');

--- a/src/core/ai/agent/SaikiAgent.ts
+++ b/src/core/ai/agent/SaikiAgent.ts
@@ -9,7 +9,7 @@ import { ValidatedLLMConfig, LLMConfig, McpServerConfig } from '../../config/sch
 import {
     getSupportedProviders,
     getDefaultModelForProvider,
-    inferProviderFromModel,
+    getProviderFromModel,
     LLMProvider,
     LLM_REGISTRY,
     ModelInfo,
@@ -830,7 +830,11 @@ export class SaikiAgent {
      * ```
      */
     public inferProviderFromModel(modelName: string): LLMProvider | null {
-        return inferProviderFromModel(modelName);
+        try {
+            return getProviderFromModel(modelName) as LLMProvider;
+        } catch {
+            return null;
+        }
     }
 
     // ============= MCP SERVER MANAGEMENT =============

--- a/src/core/ai/agent/SaikiAgent.ts
+++ b/src/core/ai/agent/SaikiAgent.ts
@@ -9,6 +9,7 @@ import { ValidatedLLMConfig, LLMConfig, McpServerConfig } from '../../config/sch
 import {
     getSupportedProviders,
     getDefaultModelForProvider,
+    inferProviderFromModel,
     LLMProvider,
     LLM_REGISTRY,
     ModelInfo,
@@ -807,6 +808,29 @@ export class SaikiAgent {
             ...model,
             isDefault: model.name === defaultModel,
         }));
+    }
+
+    /**
+     * Infers the provider from a model name.
+     * Searches through all supported providers to find which one supports the given model.
+     *
+     * @param modelName The model name to search for
+     * @returns The provider name if found, null if the model is not supported
+     *
+     * @example
+     * ```typescript
+     * const provider = agent.inferProviderFromModel('gpt-4o');
+     * console.log(provider); // 'openai'
+     *
+     * const provider2 = agent.inferProviderFromModel('claude-4-sonnet-20250514');
+     * console.log(provider2); // 'anthropic'
+     *
+     * const provider3 = agent.inferProviderFromModel('unknown-model');
+     * console.log(provider3); // null
+     * ```
+     */
+    public inferProviderFromModel(modelName: string): LLMProvider | null {
+        return inferProviderFromModel(modelName);
     }
 
     // ============= MCP SERVER MANAGEMENT =============

--- a/src/core/ai/llm/registry.ts
+++ b/src/core/ai/llm/registry.ts
@@ -143,23 +143,6 @@ export function getMaxInputTokensForModel(provider: string, model: string): numb
 }
 
 /**
- * Infers the provider from a model name by searching the registry.
- * @param modelName The model name to search for.
- * @returns The provider name if found, null otherwise.
- */
-export function inferProviderFromModel(modelName: string): LLMProvider | null {
-    const lowerModel = modelName.toLowerCase();
-
-    for (const [provider, info] of Object.entries(LLM_REGISTRY)) {
-        if (info.models.some((model) => model.name.toLowerCase() === lowerModel)) {
-            return provider as LLMProvider;
-        }
-    }
-
-    return null;
-}
-
-/**
  * Validates if a provider and model combination is supported.
  * @param provider The provider name.
  * @param model The model name.

--- a/src/core/ai/llm/registry.ts
+++ b/src/core/ai/llm/registry.ts
@@ -143,6 +143,23 @@ export function getMaxInputTokensForModel(provider: string, model: string): numb
 }
 
 /**
+ * Infers the provider from a model name by searching the registry.
+ * @param modelName The model name to search for.
+ * @returns The provider name if found, null otherwise.
+ */
+export function inferProviderFromModel(modelName: string): LLMProvider | null {
+    const lowerModel = modelName.toLowerCase();
+
+    for (const [provider, info] of Object.entries(LLM_REGISTRY)) {
+        if (info.models.some((model) => model.name.toLowerCase() === lowerModel)) {
+            return provider as LLMProvider;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Validates if a provider and model combination is supported.
  * @param provider The provider name.
  * @param model The model name.


### PR DESCRIPTION
mainly addressing comments in #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands: `/tools` to list available MCP tools, `/prompt` to display the current system prompt, and `/docs` to open Saiki documentation in the browser.
  * Introduced detailed contextual help subcommands for `/session` and `/model` commands.
  * Added methods to list supported LLM providers and models, infer providers from model names, and retrieve the resolved system prompt.
  * Enhanced command categorization with new groups like Tool Management, Prompt Management, and Documentation.

* **Improvements**
  * The `/model switch` command now automatically infers the provider from the model name.
  * Refined CLI command display order and grouping for better usability.
  * Improved error handling and user guidance for unknown models and commands.
  * Updated CLI logging to highlight session loading status more clearly.
  * Enhanced formatting and clarity in CLI help and error messages.

* **Bug Fixes**
  * Improved validation and error messages for unsupported LLM providers and models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->