### PR TITLE
Adding a file prompt contributor

### DIFF
--- a/docs/docs/guides/configuring-saiki/systemPrompt.md
+++ b/docs/docs/guides/configuring-saiki/systemPrompt.md
@@ -88,14 +88,58 @@ systemPrompt:
 #### Available Dynamic Sources
 - **`dateTime`:** Automatically adds current date/time context
 
+### File Contributors
+- **Type:** `file`
+- **Required:** `files` field
+- **Use case:** Include content from external files in your system prompt
+- **Supported formats:** Only `.md` and `.txt` files are supported
+- **Control:** Enable/disable with `enabled` field
+
+```yaml
+systemPrompt:
+  contributors:
+    - id: project-context
+      type: file
+      priority: 10
+      files:
+        - ./README.md
+        - ./docs/guidelines.md
+        - ./CONTRIBUTING.txt
+      options:
+        includeFilenames: true
+        separator: "\n\n---\n\n"
+        errorHandling: "skip"
+        maxFileSize: 50000
+        includeMetadata: false
+```
+
+#### File Contributor Options
+- **`files`** (array): List of file paths to include (only `.md` and `.txt` files)
+- **`options.includeFilenames`** (boolean): Whether to include filename headers (default: `true`)
+- **`options.separator`** (string): Text to separate multiple files (default: `"\n\n---\n\n"`)
+- **`options.errorHandling`** (string): How to handle missing/invalid files - `"skip"`, `"error"` (default: `"skip"`)
+- **`options.maxFileSize`** (number): Maximum file size in bytes (default: `100000`)
+- **`options.includeMetadata`** (boolean): Include file size and modification time (default: `false`)
+
+#### File Contributor Use Cases
+- Include project documentation and guidelines
+- Add code style guides and best practices
+- Provide domain-specific knowledge from markdown files
+- Include API documentation or specification files
+- Add context-specific instructions for different projects
+
+**Note:** File contributors only support `.md` and `.txt` files. Other file types will be skipped (or cause an error if `errorHandling: "error"` is set).
+
 ### Contributor Fields
 
 - **`id`** (string): Unique identifier for the contributor
-- **`type`** (`static` | `dynamic`): Type of contributor
+- **`type`** (`static` | `dynamic` | `file`): Type of contributor
 - **`priority`** (number): Execution order (lower numbers first)
 - **`enabled`** (boolean, optional): Whether contributor is active (default: true)
 - **`content`** (string): Static content (required for `static` type)
 - **`source`** (string): Dynamic source identifier (required for `dynamic` type)
+- **`files`** (array): List of file paths to include (required for `file` type)
+- **`options`** (object, optional): Configuration options for `file` type contributors
 
 ## Examples
 
@@ -147,6 +191,43 @@ systemPrompt:
         - Escalate complex technical issues to engineering team
 ```
 
+### Complete Multi-Contributor Example
+```yaml
+systemPrompt:
+  contributors:
+    - id: core-behavior
+      type: static
+      priority: 1
+      content: |
+        You are a professional software development assistant.
+        You help with coding, documentation, and project management.
+    
+    - id: project-context
+      type: file
+      priority: 5
+      files:
+        - ./README.md
+        - ./CONTRIBUTING.md
+        - ./docs/architecture.md
+      options:
+        includeFilenames: true
+        separator: "\n\n---\n\n"
+        errorHandling: "skip"
+        maxFileSize: 50000
+    
+    - id: current-time
+      type: dynamic
+      priority: 10
+      source: dateTime
+    
+    - id: additional-instructions
+      type: static
+      priority: 15
+      content: |
+        Always provide code examples when relevant.
+        Reference the project documentation when making suggestions.
+```
+
 ## Best Practices
 
 1. **Keep it focused:** Clear, specific instructions work better than lengthy prompts
@@ -154,4 +235,8 @@ systemPrompt:
 3. **Test behavior:** Validate that your prompt produces the desired agent behavior
 4. **Dynamic content:** Use dynamic sources for time-sensitive or contextual information
 5. **Modular approach:** Break complex prompts into separate contributors for easier management
+6. **File contributors:** Use File contributors to include project-specific documentation and guidelines
+7. **File format restrictions:** Remember that File contributors only support `.md` and `.txt` files
+8. **Error handling:** Use `"skip"` error handling for optional files, `"error"` for required files
+9. **File size limits:** Set appropriate `maxFileSize` limits to prevent memory issues with large files
 

--- a/docs/docs/guides/configuring-saiki/systemPrompt.md
+++ b/docs/docs/guides/configuring-saiki/systemPrompt.md
@@ -87,6 +87,44 @@ systemPrompt:
 
 #### Available Dynamic Sources
 - **`dateTime`:** Automatically adds current date/time context
+- **`resources`:** Automatically includes resources from connected MCP servers (disabled by default)
+
+##### MCP Resources Contributor
+
+The `resources` dynamic contributor automatically fetches and includes resources from all connected MCP servers. This is particularly useful when you have MCP servers that provide contextual information like documentation, database schemas, or configuration files.
+
+**Key Features:**
+- Automatically discovers all available resources from connected MCP servers
+- Fetches and includes resource content in the system prompt
+- Wraps each resource in XML tags with the resource URI for clear identification
+- Handles errors gracefully (shows error message if resource can't be loaded)
+- **Disabled by default** to avoid performance impact
+
+**Example Usage:**
+```yaml
+systemPrompt:
+  contributors:
+    - id: main-prompt
+      type: static
+      priority: 1
+      content: |
+        You are a helpful assistant with access to project resources.
+    
+    - id: resources
+      type: dynamic
+      priority: 10
+      source: resources
+      enabled: true  # Enable MCP resources
+```
+
+**Output Format:**
+The resources contributor wraps all resources in XML tags:
+```xml
+<resources>
+<resource uri="file:///project/schema.sql">CREATE TABLE users...</resource>
+<resource uri="config://app-settings">{"debug": true, ...}</resource>
+</resources>
+```
 
 ### File Contributors
 - **Type:** `file`
@@ -120,6 +158,8 @@ systemPrompt:
 - **`options.errorHandling`** (string): How to handle missing/invalid files - `"skip"`, `"error"` (default: `"skip"`)
 - **`options.maxFileSize`** (number): Maximum file size in bytes (default: `100000`)
 - **`options.includeMetadata`** (boolean): Include file size and modification time (default: `false`)
+
+**Note:** Files are always read using UTF-8 encoding.
 
 #### File Contributor Use Cases
 - Include project documentation and guidelines
@@ -201,6 +241,7 @@ systemPrompt:
       content: |
         You are a professional software development assistant.
         You help with coding, documentation, and project management.
+        You have access to project files and MCP resources.
     
     - id: project-context
       type: file
@@ -220,12 +261,18 @@ systemPrompt:
       priority: 10
       source: dateTime
     
+    - id: mcp-resources
+      type: dynamic
+      priority: 12
+      source: resources
+      enabled: true
+    
     - id: additional-instructions
       type: static
       priority: 15
       content: |
         Always provide code examples when relevant.
-        Reference the project documentation when making suggestions.
+        Reference the project documentation and available resources when making suggestions.
 ```
 
 ## Best Practices
@@ -239,4 +286,6 @@ systemPrompt:
 7. **File format restrictions:** Remember that File contributors only support `.md` and `.txt` files
 8. **Error handling:** Use `"skip"` error handling for optional files, `"error"` for required files
 9. **File size limits:** Set appropriate `maxFileSize` limits to prevent memory issues with large files
+10. **MCP resources:** Enable the `resources` contributor when you want to include context from MCP servers
+11. **Performance considerations:** Be mindful that the `resources` contributor fetches all MCP resources on each prompt build
 

--- a/docs/how-to-saiki.md
+++ b/docs/how-to-saiki.md
@@ -89,6 +89,12 @@ systemPrompt:
       type: dynamic
       priority: 20
       source: dateTime
+    
+    - id: mcp-resources
+      type: dynamic
+      priority: 25
+      source: resources
+      enabled: true
 ```
 
 **File Contributor Options:**
@@ -99,12 +105,24 @@ systemPrompt:
 - `options.maxFileSize`: Maximum file size in bytes (default: 100000)
 - `options.includeMetadata`: Include file size and modification time (default: false)
 
+**Note:** Files are always read using UTF-8 encoding.
+
+**Dynamic Contributor Sources:**
+- `dateTime`: Automatically adds current date and time
+- `resources`: Includes resources from connected MCP servers (disabled by default for performance)
+
 **Use Cases for File Contributors:**
 - Include project documentation and guidelines
 - Add code style guides and best practices
 - Provide domain-specific knowledge from markdown files
 - Include API documentation or specification files
 - Add context-specific instructions for different projects
+
+**Use Cases for MCP Resources:**
+- Include database schemas from database MCP servers
+- Add configuration files from configuration MCP servers  
+- Include documentation from documentation MCP servers
+- Provide real-time context from connected services
 
 ---
 

--- a/docs/how-to-saiki.md
+++ b/docs/how-to-saiki.md
@@ -1,0 +1,219 @@
+# Saiki Usage Guide for LLM Agents
+
+This document provides a concise guide for using the Saiki agent runtime, optimized for RAG and consumption by other LLMs.
+
+---
+
+## 1. Core Concepts
+
+### What is Saiki?
+Saiki is a lightweight runtime for creating and running AI agents. It translates natural language prompts into actions using configured tools and LLMs. It can be controlled via CLI, a programmatic SDK, or a REST API.
+
+### Installation
+Install the Saiki CLI globally via npm:
+```bash
+npm install -g @truffle-ai/saiki
+```
+
+### LLM API Keys
+Saiki requires API keys for the desired LLM provider. Set them as environment variables.
+```bash
+# For OpenAI (e.g., gpt-4o)
+export OPENAI_API_KEY="your_key"
+
+# For Anthropic (e.g., claude-3-sonnet)
+export ANTHROPIC_API_KEY="your_key"
+
+# For Google (e.g., gemini-1.5-pro)
+export GOOGLE_GENERATIVE_AI_API_KEY="your_key"
+```
+
+### Agent Configuration (`agent.yml`)
+Agent behavior is defined in a YAML file (default: `agents/agent.yml`). This file specifies the LLM, tools (via MCP servers), and system prompt.
+
+**Example `agent.yml`:**
+```yaml
+# Connect to tool servers via Model Context Protocol (MCP)
+mcpServers:
+  filesystem:
+    type: stdio
+    command: npx
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+  puppeteer:
+    type: stdio
+    command: npx
+    args: ['-y', '@truffle-ai/puppeteer-server']
+
+# Configure the Large Language Model
+llm:
+  provider: openai
+  model: gpt-4o
+  apiKey: $OPENAI_API_KEY # Reads from environment variable
+
+# Define the agent's persona and instructions
+systemPrompt: |
+  You are Saiki, an expert coding assistant.
+  You have access to a filesystem and a browser.
+  Think step-by-step to solve the user's request.
+```
+
+### Advanced System Prompt Configuration
+
+For more complex system prompts, you can use the contributor-based configuration format that allows mixing static content, dynamic content, and file-based context:
+
+```yaml
+systemPrompt:
+  contributors:
+    - id: main-prompt
+      type: static
+      priority: 0
+      content: |
+        You are Saiki, an expert coding assistant.
+        You have access to a filesystem and a browser.
+    
+    - id: project-context
+      type: file
+      priority: 10
+      files:
+        - ./README.md
+        - ./docs/architecture.md
+        - ./CONTRIBUTING.md
+      options:
+        includeFilenames: true
+        separator: "\n\n---\n\n"
+        errorHandling: skip
+        maxFileSize: 50000
+        includeMetadata: false
+    
+    - id: current-time
+      type: dynamic
+      priority: 20
+      source: dateTime
+```
+
+**File Contributor Options:**
+- `files`: Array of file paths to include (.md and .txt files only)
+- `options.includeFilenames`: Whether to include filename headers (default: true)
+- `options.separator`: Text to separate multiple files (default: "\n\n---\n\n")
+- `options.errorHandling`: How to handle missing files - "skip", "placeholder", or "error" (default: "skip")
+- `options.maxFileSize`: Maximum file size in bytes (default: 100000)
+- `options.encoding`: File encoding (default: "utf-8")
+- `options.includeMetadata`: Include file size and modification time (default: false)
+
+**Use Cases for File Contributors:**
+- Include project documentation and guidelines
+- Add code style guides and best practices
+- Provide domain-specific knowledge from markdown files
+- Include API documentation or specification files
+- Add context-specific instructions for different projects
+
+---
+
+## 2. Usage Methods
+
+Saiki can be used via its CLI, a TypeScript SDK, or as a server with a REST API.
+
+### Method 1: CLI Usage
+
+The `saiki` command can run one-shot prompts or start in different modes.
+
+**One-shot prompt:**
+Execute a task directly from the command line.
+```bash
+saiki "create a new file named 'test.txt' with the content 'hello world'"
+```
+
+**Interactive CLI:**
+Start a chat session in the terminal.
+```bash
+saiki
+```
+
+**Key CLI Flags:**
+- `-m, --model <model_name>`: Switch LLM model (e.g., `claude-3-sonnet-20240229`). Overrides config file.
+- `-a, --agent <path/to/agent.yml>`: Use a specific agent configuration file.
+- `--mode <mode>`: Change the run mode.
+- `--new-session [id]`: Start a new chat session.
+
+**CLI Run Modes (`--mode`):**
+
+| Mode       | Command                       | Description                               |
+|------------|-------------------------------|-------------------------------------------|
+| `cli`      | `saiki`                       | Interactive or one-shot terminal commands.|
+| `web`      | `saiki --mode web`            | Starts a web UI (default port: 3000).     |
+| `server`   | `saiki --mode server`         | Starts a REST/WebSocket server (port: 3001).|
+| `mcp`      | `saiki --mode mcp`            | Exposes the agent as a tool via MCP/stdio.|
+| `discord`  | `saiki --mode discord`        | Runs the agent as a Discord bot.          |
+| `telegram` | `saiki --mode telegram`       | Runs the agent as a Telegram bot.         |
+
+**Project Scaffolding:**
+- `saiki create-app`: Create a new Saiki project structure.
+- `saiki init-app`: Initialize Saiki in an existing TypeScript project.
+
+### Method 2: Programmatic SDK (`SaikiAgent`)
+
+Use the `SaikiAgent` class in your TypeScript/JavaScript projects for full programmatic control.
+
+**Installation for a project:**
+```bash
+npm install @truffle-ai/saiki
+```
+
+**Example SDK Usage:**
+```ts
+import 'dotenv/config';
+import { SaikiAgent, loadAgentConfig } from '@truffle-ai/saiki';
+
+// Load configuration from a file
+const config = await loadAgentConfig('./agents/agent.yml');
+
+// Create and start the agent
+const agent = new SaikiAgent(config);
+await agent.start(); // Initializes services like MCP servers
+
+// Run a single task
+const response = await agent.run('List the 3 largest files in the current directory.');
+console.log(response);
+
+// Hold a conversation (state is maintained automatically)
+await agent.run('Write a function that adds two numbers.');
+await agent.run('Now add type annotations to it.');
+
+// Reset the conversation history
+agent.resetConversation();
+
+// Stop the agent and disconnect services
+await agent.stop();
+```
+
+### Method 3: REST API (Server Mode)
+
+Run Saiki as a headless server to interact with it via HTTP requests.
+
+**Start the server:**
+```bash
+# The server will run on http://localhost:3001 by default
+saiki --mode server
+```
+
+**Key API Endpoints:**
+- `POST /api/message`: Send a prompt asynchronously. The agent will process it and you can receive events via WebSocket.
+  - Body: `{ "message": "your prompt here" }`
+- `POST /api/message-sync`: Send a prompt and wait for the complete response.
+  - Body: `{ "message": "your prompt here" }`
+- `POST /api/reset`: Resets the current conversation session.
+- `GET /api/mcp/servers`: Lists the connected MCP tool servers.
+
+---
+
+## 3. Tools and the Model Context Protocol (MCP)
+
+Saiki uses the **Model Context Protocol (MCP)** to communicate with tools. Tools run as separate server processes. You connect Saiki to them by listing them under `mcpServers` in your `agent.yml`.
+
+**Common Tool Servers:**
+- **`@modelcontextprotocol/server-filesystem`**: Provides tools for reading, writing, and listing files.
+- **`@truffle-ai/puppeteer-server`**: Provides tools for web browsing and scraping.
+- **`@truffle-ai/web-search`**: Provides tools for performing web searches.
+
+**Executing Tools:**
+When an LLM agent uses Saiki, it should issue natural language commands. Saiki's LLM will determine which tool to call. The agent's `systemPrompt` should inform the LLM about the available tools (e.g., "You have access to a filesystem and a browser"). The LLM then generates tool calls that Saiki executes. 

--- a/docs/how-to-saiki.md
+++ b/docs/how-to-saiki.md
@@ -81,7 +81,7 @@ systemPrompt:
       options:
         includeFilenames: true
         separator: "\n\n---\n\n"
-        errorHandling: skip
+        errorHandling: "skip"
         maxFileSize: 50000
         includeMetadata: false
     
@@ -95,9 +95,8 @@ systemPrompt:
 - `files`: Array of file paths to include (.md and .txt files only)
 - `options.includeFilenames`: Whether to include filename headers (default: true)
 - `options.separator`: Text to separate multiple files (default: "\n\n---\n\n")
-- `options.errorHandling`: How to handle missing files - "skip", "placeholder", or "error" (default: "skip")
+- `options.errorHandling`: How to handle missing files - "skip" or "error" (default: "skip")
 - `options.maxFileSize`: Maximum file size in bytes (default: 100000)
-- `options.encoding`: File encoding (default: "utf-8")
 - `options.includeMetadata`: Include file size and modification time (default: false)
 
 **Use Cases for File Contributors:**

--- a/examples/file-context-example.yml
+++ b/examples/file-context-example.yml
@@ -1,0 +1,60 @@
+# Example: Agent Configuration with File-Based Context
+# This demonstrates how to use the new file contributor feature
+# to automatically include local files as context for your agent
+
+# Configure the Large Language Model
+llm:
+  provider: openai
+  model: gpt-4o
+  apiKey: $OPENAI_API_KEY
+
+# Define system prompt with file-based context
+systemPrompt:
+  contributors:
+    # Main agent instructions
+    - id: base-prompt
+      type: static
+      priority: 0
+      content: |
+        You are a helpful coding assistant with knowledge of the current project.
+        You have access to project documentation and context files.
+        
+    # Include project documentation files
+    - id: project-docs
+      type: file
+      priority: 10
+      files:
+        - ./README.md
+        - ./docs/architecture.md
+        - ./CONTRIBUTING.md
+      options:
+        includeFilenames: true
+        separator: "\n\n---\n\n"
+        errorHandling: skip
+        maxFileSize: 50000
+        includeMetadata: false
+        
+    # Include coding guidelines
+    - id: coding-standards
+      type: file
+      priority: 20
+      files:
+        - ./docs/coding-standards.md
+        - ./docs/best-practices.txt
+      options:
+        includeFilenames: true
+        includeMetadata: true
+        errorHandling: placeholder
+        
+    # Add current date/time
+    - id: current-time
+      type: dynamic
+      priority: 30
+      source: dateTime
+
+# Optional: Connect to MCP servers for additional tools
+mcpServers:
+  filesystem:
+    type: stdio
+    command: npx
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.'] 

--- a/examples/file-context-example.yml
+++ b/examples/file-context-example.yml
@@ -44,7 +44,7 @@ systemPrompt:
       options:
         includeFilenames: true
         includeMetadata: true
-        errorHandling: placeholder
+        errorHandling: "skip"
         
     # Add current date/time
     - id: current-time

--- a/src/core/ai/systemPrompt/contributors.test.ts
+++ b/src/core/ai/systemPrompt/contributors.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { FileContributor } from './contributors.js';
+import { writeFile, mkdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { DynamicContributorContext } from './types.js';
+
+describe('FileContributor', () => {
+    const testDir = join(process.cwd(), 'test-files');
+    const mockContext: DynamicContributorContext = {
+        mcpManager: {} as any,
+    };
+
+    beforeEach(async () => {
+        // Create test directory and files
+        await mkdir(testDir, { recursive: true });
+
+        // Create test files
+        await writeFile(
+            join(testDir, 'test1.md'),
+            '# Test Document 1\n\nThis is the first test document.'
+        );
+        await writeFile(join(testDir, 'test2.txt'), 'This is a plain text file.\nSecond line.');
+        await writeFile(join(testDir, 'large.md'), 'x'.repeat(200000)); // Large file for testing
+        await writeFile(join(testDir, 'invalid.json'), '{"key": "value"}'); // Invalid file type
+    });
+
+    afterEach(async () => {
+        // Clean up test files
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    test('should read single markdown file with default options', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'test1.md')]);
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('<fileContext>');
+        expect(result).toContain('test-files/test1.md');
+        expect(result).toContain('# Test Document 1');
+        expect(result).toContain('This is the first test document.');
+        expect(result).toContain('</fileContext>');
+    });
+
+    test('should read multiple files with separator', async () => {
+        const contributor = new FileContributor(
+            'test',
+            0,
+            [join(testDir, 'test1.md'), join(testDir, 'test2.txt')],
+            {
+                separator: '\n\n===\n\n',
+            }
+        );
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).toContain('This is a plain text file.');
+        expect(result).toContain('===');
+    });
+
+    test('should handle missing files with skip mode', async () => {
+        const contributor = new FileContributor(
+            'test',
+            0,
+            [join(testDir, 'missing.md'), join(testDir, 'test1.md')],
+            {
+                errorHandling: 'skip',
+            }
+        );
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).not.toContain('missing.md');
+    });
+
+    test('should handle missing files with placeholder mode', async () => {
+        const contributor = new FileContributor(
+            'test',
+            0,
+            [join(testDir, 'missing.md'), join(testDir, 'test1.md')],
+            {
+                errorHandling: 'placeholder',
+            }
+        );
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).toContain('test-files/missing.md could not be read:');
+    });
+
+    test('should throw error for missing files with error mode', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'missing.md')], {
+            errorHandling: 'error',
+        });
+
+        await expect(contributor.getContent(mockContext)).rejects.toThrow('Failed to read file');
+    });
+
+    test('should skip large files with skip mode', async () => {
+        const contributor = new FileContributor(
+            'test',
+            0,
+            [join(testDir, 'large.md'), join(testDir, 'test1.md')],
+            {
+                maxFileSize: 1000,
+                errorHandling: 'skip',
+            }
+        );
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).not.toContain('large.md');
+    });
+
+    test('should handle invalid file types with placeholder mode', async () => {
+        const contributor = new FileContributor(
+            'test',
+            0,
+            [join(testDir, 'invalid.json'), join(testDir, 'test1.md')],
+            {
+                errorHandling: 'placeholder',
+            }
+        );
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).toContain('test-files/invalid.json skipped: not a .md or .txt file');
+    });
+
+    test('should exclude filenames when configured', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'test1.md')], {
+            includeFilenames: false,
+        });
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('# Test Document 1');
+        expect(result).not.toContain('test-files/test1.md');
+    });
+
+    test('should include metadata when configured', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'test1.md')], {
+            includeMetadata: true,
+        });
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toContain('*File size:');
+        expect(result).toContain('Modified:');
+    });
+
+    test('should return empty context when no files can be loaded', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'missing.md')], {
+            errorHandling: 'skip',
+        });
+        const result = await contributor.getContent(mockContext);
+
+        expect(result).toBe('<fileContext>No files could be loaded</fileContext>');
+    });
+});

--- a/src/core/ai/systemPrompt/contributors.test.ts
+++ b/src/core/ai/systemPrompt/contributors.test.ts
@@ -71,22 +71,20 @@ describe('FileContributor', () => {
         expect(result).not.toContain('missing.md');
     });
 
-    test('should handle missing files with placeholder mode', async () => {
+    test('should handle missing files with error mode', async () => {
         const contributor = new FileContributor(
             'test',
             0,
             [join(testDir, 'missing.md'), join(testDir, 'test1.md')],
             {
-                errorHandling: 'placeholder',
+                errorHandling: 'error',
             }
         );
-        const result = await contributor.getContent(mockContext);
 
-        expect(result).toContain('# Test Document 1');
-        expect(result).toContain('test-files/missing.md could not be read:');
+        await expect(contributor.getContent(mockContext)).rejects.toThrow('Failed to read file');
     });
 
-    test('should throw error for missing files with error mode', async () => {
+    test('should throw error for missing files with single file error mode', async () => {
         const contributor = new FileContributor('test', 0, [join(testDir, 'missing.md')], {
             errorHandling: 'error',
         });
@@ -110,19 +108,29 @@ describe('FileContributor', () => {
         expect(result).not.toContain('large.md');
     });
 
-    test('should handle invalid file types with placeholder mode', async () => {
+    test('should handle invalid file types with skip mode', async () => {
         const contributor = new FileContributor(
             'test',
             0,
             [join(testDir, 'invalid.json'), join(testDir, 'test1.md')],
             {
-                errorHandling: 'placeholder',
+                errorHandling: 'skip',
             }
         );
         const result = await contributor.getContent(mockContext);
 
         expect(result).toContain('# Test Document 1');
-        expect(result).toContain('test-files/invalid.json skipped: not a .md or .txt file');
+        expect(result).not.toContain('invalid.json');
+    });
+
+    test('should throw error for invalid file types with error mode', async () => {
+        const contributor = new FileContributor('test', 0, [join(testDir, 'invalid.json')], {
+            errorHandling: 'error',
+        });
+
+        await expect(contributor.getContent(mockContext)).rejects.toThrow(
+            'is not a .md or .txt file'
+        );
     });
 
     test('should exclude filenames when configured', async () => {

--- a/src/core/ai/systemPrompt/contributors.ts
+++ b/src/core/ai/systemPrompt/contributors.ts
@@ -29,9 +29,8 @@ export class DynamicContributor implements SystemPromptContributor {
 export interface FileContributorOptions {
     includeFilenames?: boolean | undefined;
     separator?: string | undefined;
-    errorHandling?: 'skip' | 'placeholder' | 'error' | undefined;
+    errorHandling?: 'skip' | 'error' | undefined;
     maxFileSize?: number | undefined;
-    encoding?: string | undefined;
     includeMetadata?: boolean | undefined;
 }
 
@@ -49,7 +48,6 @@ export class FileContributor implements SystemPromptContributor {
             separator = '\n\n---\n\n',
             errorHandling = 'skip',
             maxFileSize = 100000,
-            encoding = 'utf-8',
             includeMetadata = false,
         } = this.options;
 
@@ -65,8 +63,6 @@ export class FileContributor implements SystemPromptContributor {
                 if (ext !== '.md' && ext !== '.txt') {
                     if (errorHandling === 'error') {
                         throw new Error(`File ${filePath} is not a .md or .txt file`);
-                    } else if (errorHandling === 'placeholder') {
-                        fileParts.push(`[File ${filePath} skipped: not a .md or .txt file]`);
                     }
                     continue;
                 }
@@ -78,16 +74,12 @@ export class FileContributor implements SystemPromptContributor {
                         throw new Error(
                             `File ${filePath} exceeds maximum size of ${maxFileSize} bytes`
                         );
-                    } else if (errorHandling === 'placeholder') {
-                        fileParts.push(
-                            `[File ${filePath} skipped: exceeds maximum size of ${maxFileSize} bytes]`
-                        );
                     }
                     continue;
                 }
 
-                // Read file content
-                const content = await readFile(resolvedPath, { encoding: encoding as any });
+                // Read file content (always utf-8)
+                const content = await readFile(resolvedPath, { encoding: 'utf-8' });
 
                 // Build file part
                 let filePart = '';
@@ -106,10 +98,6 @@ export class FileContributor implements SystemPromptContributor {
             } catch (error: any) {
                 if (errorHandling === 'error') {
                     throw new Error(`Failed to read file ${filePath}: ${error.message || error}`);
-                } else if (errorHandling === 'placeholder') {
-                    fileParts.push(
-                        `[File ${filePath} could not be read: ${error.message || error}]`
-                    );
                 }
                 // 'skip' mode - do nothing, continue to next file
             }

--- a/src/core/ai/systemPrompt/contributors.ts
+++ b/src/core/ai/systemPrompt/contributors.ts
@@ -1,4 +1,6 @@
 import { SystemPromptContributor, DynamicContributorContext } from './types.js';
+import { readFile, stat } from 'fs/promises';
+import { resolve, extname } from 'path';
 
 export class StaticContributor implements SystemPromptContributor {
     constructor(
@@ -21,5 +23,103 @@ export class DynamicContributor implements SystemPromptContributor {
 
     async getContent(context: DynamicContributorContext): Promise<string> {
         return this.promptGenerator(context);
+    }
+}
+
+export interface FileContributorOptions {
+    includeFilenames?: boolean | undefined;
+    separator?: string | undefined;
+    errorHandling?: 'skip' | 'placeholder' | 'error' | undefined;
+    maxFileSize?: number | undefined;
+    encoding?: string | undefined;
+    includeMetadata?: boolean | undefined;
+}
+
+export class FileContributor implements SystemPromptContributor {
+    constructor(
+        public id: string,
+        public priority: number,
+        private files: string[],
+        private options: FileContributorOptions = {}
+    ) {}
+
+    async getContent(_context: DynamicContributorContext): Promise<string> {
+        const {
+            includeFilenames = true,
+            separator = '\n\n---\n\n',
+            errorHandling = 'skip',
+            maxFileSize = 100000,
+            encoding = 'utf-8',
+            includeMetadata = false,
+        } = this.options;
+
+        const fileParts: string[] = [];
+
+        for (const filePath of this.files) {
+            try {
+                // Resolve relative paths
+                const resolvedPath = resolve(filePath);
+
+                // Check if file is .md or .txt
+                const ext = extname(resolvedPath).toLowerCase();
+                if (ext !== '.md' && ext !== '.txt') {
+                    if (errorHandling === 'error') {
+                        throw new Error(`File ${filePath} is not a .md or .txt file`);
+                    } else if (errorHandling === 'placeholder') {
+                        fileParts.push(`[File ${filePath} skipped: not a .md or .txt file]`);
+                    }
+                    continue;
+                }
+
+                // Check file size
+                const stats = await stat(resolvedPath);
+                if (stats.size > maxFileSize) {
+                    if (errorHandling === 'error') {
+                        throw new Error(
+                            `File ${filePath} exceeds maximum size of ${maxFileSize} bytes`
+                        );
+                    } else if (errorHandling === 'placeholder') {
+                        fileParts.push(
+                            `[File ${filePath} skipped: exceeds maximum size of ${maxFileSize} bytes]`
+                        );
+                    }
+                    continue;
+                }
+
+                // Read file content
+                const content = await readFile(resolvedPath, { encoding: encoding as any });
+
+                // Build file part
+                let filePart = '';
+
+                if (includeFilenames) {
+                    filePart += `## ${filePath}\n\n`;
+                }
+
+                if (includeMetadata) {
+                    filePart += `*File size: ${stats.size} bytes, Modified: ${stats.mtime.toISOString()}*\n\n`;
+                }
+
+                filePart += content;
+
+                fileParts.push(filePart);
+            } catch (error: any) {
+                if (errorHandling === 'error') {
+                    throw new Error(`Failed to read file ${filePath}: ${error.message || error}`);
+                } else if (errorHandling === 'placeholder') {
+                    fileParts.push(
+                        `[File ${filePath} could not be read: ${error.message || error}]`
+                    );
+                }
+                // 'skip' mode - do nothing, continue to next file
+            }
+        }
+
+        if (fileParts.length === 0) {
+            return '<fileContext>No files could be loaded</fileContext>';
+        }
+
+        const combinedContent = fileParts.join(separator);
+        return `<fileContext>\n${combinedContent}\n</fileContext>`;
     }
 }

--- a/src/core/ai/systemPrompt/loader.ts
+++ b/src/core/ai/systemPrompt/loader.ts
@@ -1,6 +1,6 @@
 import { ContributorConfig, SystemPromptConfig } from '../../config/schemas.js';
 import { SystemPromptContributor } from './types.js';
-import { StaticContributor, DynamicContributor } from './contributors.js';
+import { StaticContributor, DynamicContributor, FileContributor } from './contributors.js';
 import { getPromptGenerator } from './registry.js';
 
 export function loadContributors(
@@ -42,6 +42,10 @@ export function loadContributors(
             if (!promptGenerator)
                 throw new Error(`No handler for dynamic contributor source: ${c.source}`);
             return new DynamicContributor(c.id, c.priority, promptGenerator);
+        } else if (c.type === 'file') {
+            if (!c.files || c.files.length === 0)
+                throw new Error(`File contributor "${c.id}" missing files`);
+            return new FileContributor(c.id, c.priority, c.files, c.options);
         }
         throw new Error(`Invalid contributor config: ${JSON.stringify(c)}`);
     });

--- a/src/core/ai/systemPrompt/manager.ts
+++ b/src/core/ai/systemPrompt/manager.ts
@@ -1,5 +1,5 @@
 import type { ContributorConfig, SystemPromptConfig } from '../../config/schemas.js';
-import { StaticContributor } from './contributors.js';
+import { StaticContributor, FileContributor } from './contributors.js';
 import { getPromptGenerator } from './registry.js';
 import { registerPromptGenerator } from './registry.js';
 import type { DynamicPromptGenerator } from './registry.js';
@@ -69,6 +69,15 @@ export class PromptManager {
                         `No generator registered for dynamic contributor source: ${config.source}`
                     ); // Changed error message to match manager.ts previous one
                 return new DynamicContributor(config.id, config.priority, promptGenerator);
+            } else if (config.type === 'file') {
+                if (!config.files || config.files.length === 0)
+                    throw new Error(`File contributor "${config.id}" missing files`);
+                return new FileContributor(
+                    config.id,
+                    config.priority,
+                    config.files,
+                    config.options
+                );
             }
             throw new Error(`Invalid contributor config: ${JSON.stringify(config)}`);
         });

--- a/src/core/config/schemas.ts
+++ b/src/core/config/schemas.ts
@@ -128,11 +128,11 @@ const FileContributorSchema = BaseContributorSchema.extend({
                 .default('\n\n---\n\n')
                 .describe('Separator to use between multiple files'),
             errorHandling: z
-                .enum(['skip', 'placeholder', 'error'])
+                .enum(['skip', 'error'])
                 .optional()
                 .default('skip')
                 .describe(
-                    'How to handle missing or unreadable files: skip (ignore), placeholder (show error message), or error (throw)'
+                    'How to handle missing or unreadable files: skip (ignore) or error (throw)'
                 ),
             maxFileSize: z
                 .number()

--- a/src/core/config/schemas.ts
+++ b/src/core/config/schemas.ts
@@ -141,11 +141,6 @@ const FileContributorSchema = BaseContributorSchema.extend({
                 .optional()
                 .default(100000)
                 .describe('Maximum file size in bytes (default: 100KB)'),
-            encoding: z
-                .string()
-                .optional()
-                .default('utf-8')
-                .describe('File encoding to use when reading files'),
             includeMetadata: z
                 .boolean()
                 .optional()


### PR DESCRIPTION
Introducing a new file prompt contributor to reference local files for context.

Also added a `how-to-saiki.md` initial draft for context on using saiki for creating and using agents via different modes and the SDK. (This would need to be enhanced and improved via testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including external file contents (Markdown and text files) as contributors to system prompts, with configurable options for filenames, separators, error handling, file size limits, and metadata.
  * Introduced comprehensive documentation and examples demonstrating file-based prompt configuration and usage.
  * Added a new example configuration file showcasing the file contributor feature.

* **Documentation**
  * Expanded system prompt configuration guide to detail the new file contributor type, options, and best practices.
  * Added a step-by-step usage guide for the Saiki agent runtime, covering installation, configuration, and usage methods.

* **Tests**
  * Introduced tests to verify file contributor behavior, including file reading, error handling, and content aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->