### PR TITLE
Handle ollama failures for hosted gemma3

### DIFF
--- a/src/core/ai/llm/services/vercel.ts
+++ b/src/core/ai/llm/services/vercel.ts
@@ -154,7 +154,6 @@ export class VercelLLMService implements ILLMService {
             `[VercelLLMService] Tools before formatting: ${JSON.stringify(tools, null, 2)}`
         );
 
-        // If the model supports tools, format them otherwise use an empty object
         const formattedTools = this.formatTools(tools);
 
         logger.silly(


### PR DESCRIPTION
hosted gemma3n:e2b on ollama doesn't support tools 

Updated generateText and streamText methods in vercel router to make a small test call to see if the model supports tools (checking for exact error string) before processing the request.

exact error string check is a bit brittle but there's no cleaner way

This information is cached so we don't need to repeat it after the first response

tested webui and cli streaming/non streaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by automatically detecting whether the current AI model supports tools, preventing errors when tools are not supported.

* **Refactor**
  * Enhanced performance with caching for tool support checks, reducing unnecessary repeated validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->