### PR TITLE
Add xai support with grok 4

### DIFF
--- a/docs/docs/guides/configuring-saiki/llm/providers.md
+++ b/docs/docs/guides/configuring-saiki/llm/providers.md
@@ -210,7 +210,7 @@ PERPLEXITY_API_KEY=your_perplexity_key
 
 ### xAI
 - **Grok models**: Access to xAI's Grok language models
-- **Large context**: Up to 131K tokens for Grok-3
+- **State of the art**: Grok 4 is the leader in all benchmarks!
 - **Real-time knowledge**: Trained on real-time data
 - **Reasoning**: Strong performance on complex reasoning tasks
 

--- a/docs/docs/guides/configuring-saiki/llm/providers.md
+++ b/docs/docs/guides/configuring-saiki/llm/providers.md
@@ -48,6 +48,16 @@ llm:
 
 **Supported models**: `gemma-2-9b-it`, `llama-3.3-70b-versatile`
 
+### **xAI**
+```yaml
+llm:
+  provider: xai
+  model: grok-3  # Default
+  apiKey: $XAI_API_KEY
+```
+
+**Supported models**: `grok-3`, `grok-3-mini`
+
 
 ## OpenAI-Compatible Providers
 
@@ -162,6 +172,7 @@ OPENAI_API_KEY=your_openai_key
 ANTHROPIC_API_KEY=your_anthropic_key
 GOOGLE_GENERATIVE_AI_API_KEY=your_google_key
 GROQ_API_KEY=your_groq_key
+XAI_API_KEY=your_xai_key
 
 # Custom providers
 OPENROUTER_API_KEY=your_openrouter_key
@@ -195,6 +206,12 @@ PERPLEXITY_API_KEY=your_perplexity_key
 - **Ultra-fast inference**: Fastest API responses
 - **Cost-effective**: Competitive pricing
 - **Open source models**: Access to Llama and other OSS models
+
+### xAI
+- **Grok models**: Access to xAI's Grok language models
+- **Large context**: Up to 131K tokens for Grok-3
+- **Real-time knowledge**: Trained on real-time data
+- **Reasoning**: Strong performance on complex reasoning tasks
 
 ## Choosing the Right Provider
 

--- a/docs/docs/guides/configuring-saiki/llm/providers.md
+++ b/docs/docs/guides/configuring-saiki/llm/providers.md
@@ -38,6 +38,17 @@ llm:
 
 **Supported models**: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-1.5-pro-latest`, `gemini-1.5-flash-latest`
 
+
+### **xAI**
+```yaml
+llm:
+  provider: xai
+  model: grok-4  # Default
+  apiKey: $XAI_API_KEY
+```
+
+**Supported models**: `grok-4`, `grok-3`, `grok-3-mini`
+
 ### **Groq**
 ```yaml
 llm:
@@ -47,16 +58,6 @@ llm:
 ```
 
 **Supported models**: `gemma-2-9b-it`, `llama-3.3-70b-versatile`
-
-### **xAI**
-```yaml
-llm:
-  provider: xai
-  model: grok-3  # Default
-  apiKey: $XAI_API_KEY
-```
-
-**Supported models**: `grok-3`, `grok-3-mini`
 
 
 ## OpenAI-Compatible Providers

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@ai-sdk/google": "^1.2.8",
                 "@ai-sdk/groq": "^1.2.9",
                 "@ai-sdk/openai": "^1.3.3",
+                "@ai-sdk/xai": "^1.2.17",
                 "@anthropic-ai/sdk": "^0.39.0",
                 "@clack/prompts": "^0.10.1",
                 "@modelcontextprotocol/sdk": "^1.11.0",
@@ -199,6 +200,51 @@
                 "zod": "^3.0.0"
             }
         },
+        "node_modules/@ai-sdk/openai-compatible": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.15.tgz",
+            "integrity": "sha512-868uTi5/gx0OlK8x2OT6G/q/WKATVStM4XEXMMLOo9EQTaoNDtSndhLU+4N4kuxbMS7IFaVSJcMr7mKFwV5vvQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "1.1.3",
+                "@ai-sdk/provider-utils": "2.2.8"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.0.0"
+            }
+        },
+        "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+            "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+            "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "1.1.3",
+                "nanoid": "^3.3.8",
+                "secure-json-parse": "^2.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.23.8"
+            }
+        },
         "node_modules/@ai-sdk/provider": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.0.tgz",
@@ -293,6 +339,52 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "1.1.0",
+                "nanoid": "^3.3.8",
+                "secure-json-parse": "^2.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.23.8"
+            }
+        },
+        "node_modules/@ai-sdk/xai": {
+            "version": "1.2.17",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.17.tgz",
+            "integrity": "sha512-6r7/0t5prXaUC7A0G5rs6JdsRUhtYoK9tuwZ2gbc+oad4YE7rza199Il8/FaS9xAiGplC9SPB6dK1q59IjNkUg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/openai-compatible": "0.2.15",
+                "@ai-sdk/provider": "1.1.3",
+                "@ai-sdk/provider-utils": "2.2.8"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.0.0"
+            }
+        },
+        "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/provider": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+            "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/provider-utils": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+            "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "1.1.3",
                 "nanoid": "^3.3.8",
                 "secure-json-parse": "^2.7.0"
             },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "@ai-sdk/google": "^1.2.8",
         "@ai-sdk/groq": "^1.2.9",
         "@ai-sdk/openai": "^1.3.3",
+        "@ai-sdk/xai": "^1.2.17",
         "@anthropic-ai/sdk": "^0.39.0",
         "@clack/prompts": "^0.10.1",
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/src/core/ai/llm/registry.ts
+++ b/src/core/ai/llm/registry.ts
@@ -85,8 +85,8 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
     // https://docs.x.ai/docs/models
     xai: {
         models: [
-            { name: 'grok-4', maxInputTokens: 256000 },
-            { name: 'grok-3', maxInputTokens: 131072, default: true },
+            { name: 'grok-4', maxInputTokens: 256000, default: true },
+            { name: 'grok-3', maxInputTokens: 131072 },
             { name: 'grok-3-mini', maxInputTokens: 131072 },
         ],
         supportedRouters: ['vercel'],

--- a/src/core/ai/llm/registry.ts
+++ b/src/core/ai/llm/registry.ts
@@ -24,7 +24,7 @@ export interface ProviderInfo {
 /** Fallback when we cannot determine the model's input-token limit */
 export const DEFAULT_MAX_INPUT_TOKENS = 128000;
 
-export type LLMProvider = 'openai' | 'openai-compatible' | 'anthropic' | 'google' | 'groq';
+export type LLMProvider = 'openai' | 'openai-compatible' | 'anthropic' | 'google' | 'groq' | 'xai';
 
 // Central registry of supported LLM providers and their models
 export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
@@ -78,6 +78,16 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
         models: [
             { name: 'gemma-2-9b-it', maxInputTokens: 8192 },
             { name: 'llama-3.3-70b-versatile', maxInputTokens: 128000, default: true },
+        ],
+        supportedRouters: ['vercel'],
+        baseURLSupport: 'none',
+    },
+    // https://docs.x.ai/docs/models
+    xai: {
+        models: [
+            { name: 'grok-4', maxInputTokens: 256000 },
+            { name: 'grok-3', maxInputTokens: 131072, default: true },
+            { name: 'grok-3-mini', maxInputTokens: 131072 },
         ],
         supportedRouters: ['vercel'],
         baseURLSupport: 'none',

--- a/src/core/ai/llm/services/factory.ts
+++ b/src/core/ai/llm/services/factory.ts
@@ -6,6 +6,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGroq } from '@ai-sdk/groq';
+import { createXai } from '@ai-sdk/xai';
 import { VercelLLMService } from './vercel.js';
 import { OpenAIService } from './openai.js';
 import { AnthropicService } from './anthropic.js';
@@ -123,6 +124,8 @@ function _createVercelModel(llmConfig: ValidatedLLMConfig): LanguageModelV1 {
             return createGoogleGenerativeAI({ apiKey })(model);
         case 'groq':
             return createGroq({ apiKey })(model);
+        case 'xai':
+            return createXai({ apiKey })(model);
         default:
             throw new Error(`Unsupported LLM provider: ${provider}`);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the xAI provider with Grok models (grok-4, grok-3, grok-3-mini).
  * Users can now configure and use xAI as an LLM provider, including specifying the API key via environment variables.

* **Documentation**
  * Updated guides to include setup instructions and details for the new xAI provider and its supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->