### PR TITLE
Added theme switch toggle for web UI

### DIFF
--- a/src/app/webui/components/ChatApp.tsx
+++ b/src/app/webui/components/ChatApp.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from './ui/dropdown-menu';
+import { ThemeSwitch } from './ThemeSwitch';
 
 export default function ChatApp() {
   const { messages, sendMessage, currentSessionId, switchSession, isWelcomeState, returnToWelcome, websocket } = useChatContext();
@@ -278,6 +279,7 @@ export default function ChatApp() {
           
             {/* Minimal Action Bar */}
             <div className="flex items-center space-x-1">
+              <ThemeSwitch />
               <Button 
                 variant="ghost" 
                 size="sm" 

--- a/src/app/webui/components/ThemeSwitch.tsx
+++ b/src/app/webui/components/ThemeSwitch.tsx
@@ -1,0 +1,34 @@
+import * as Switch from '@radix-ui/react-switch';
+import { Sun, Moon } from 'lucide-react';
+import { useTheme } from './hooks/useTheme';
+
+export function ThemeSwitch() {
+  const { theme, toggleTheme, hasMounted } = useTheme();
+  if (!hasMounted) return null;
+
+  const isDark = theme === 'dark';
+
+  return (
+    <Switch.Root
+      checked={isDark}
+      onCheckedChange={toggleTheme}
+      className="w-12 h-6 bg-gray-300 dark:bg-gray-700 rounded-full relative transition-colors flex items-center px-0.5"
+      aria-label="Toggle dark mode"
+    >
+      <Switch.Thumb
+        className={`
+          w-5 h-5 rounded-full shadow flex items-center justify-center
+          transition-transform transform
+          translate-x-0.5 data-[state=checked]:translate-x-[1.375rem]
+          bg-white dark:bg-gray-100
+        `}
+      >
+        {isDark ? (
+          <Moon className="w-3.5 h-3.5 text-gray-700" />
+        ) : (
+          <Sun className="w-3.5 h-3.5 text-yellow-500" />
+        )}
+      </Switch.Thumb>
+    </Switch.Root>
+  );
+}

--- a/src/app/webui/components/hooks/useTheme.ts
+++ b/src/app/webui/components/hooks/useTheme.ts
@@ -6,14 +6,28 @@ export function useTheme() {
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
-            const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
-            const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+            try {
+                const storedValue = localStorage.getItem('theme');
+                const stored =
+                    storedValue === 'light' || storedValue === 'dark' ? storedValue : null;
 
-            const resolvedTheme = stored || (prefersDark ? 'dark' : 'light');
+                const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+                const resolvedTheme = stored || (prefersDark ? 'dark' : 'light');
 
-            setTheme(resolvedTheme);
-            document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
-            setHasMounted(true);
+                setTheme(resolvedTheme);
+
+                document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+            } catch (error) {
+                console.error('Failed to access localStorage for theme:', error);
+
+                const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+                const fallbackTheme = prefersDark ? 'dark' : 'light';
+
+                setTheme(fallbackTheme);
+                document.documentElement.classList.toggle('dark', fallbackTheme === 'dark');
+            } finally {
+                setHasMounted(true);
+            }
         }
     }, []);
 

--- a/src/app/webui/components/hooks/useTheme.ts
+++ b/src/app/webui/components/hooks/useTheme.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+export function useTheme() {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+            const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+
+            const resolvedTheme = stored || (prefersDark ? 'dark' : 'light');
+
+            setTheme(resolvedTheme);
+            document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+            setHasMounted(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!hasMounted || typeof window === 'undefined') return;
+
+        localStorage.setItem('theme', theme);
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+    }, [theme, hasMounted]);
+
+    const toggleTheme = (checked: boolean) => {
+        setTheme(checked ? 'dark' : 'light');
+    };
+
+    return { theme, toggleTheme, hasMounted };
+}


### PR DESCRIPTION
Added theme switch to toggle between light and dark theme for web UI.

Closes #223 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme switcher to the chat app header, allowing users to toggle between light and dark modes.
  * Introduced a toggle switch with sun and moon icons for visual feedback on the current theme.
  * The app now remembers your preferred theme and automatically applies it based on your system settings or previous choice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->