### PR TITLE
bug: mask apiKey in API responses to enhance security

### DIFF
--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -449,6 +449,11 @@ export async function initializeApi(agent: SaikiAgent, agentCardOverride?: Parti
                 ? agent.getEffectiveConfig(sessionId as string).llm
                 : agent.getCurrentLLMConfig();
 
+            // Mask apiKey before returning
+            if (currentConfig && currentConfig.apiKey) {
+                currentConfig.apiKey = '[REDACTED]';
+            }
+
             res.json({ config: currentConfig });
         } catch (error: any) {
             logger.error(`Error getting current LLM config: ${error.message}`);
@@ -508,6 +513,10 @@ export async function initializeApi(agent: SaikiAgent, agentCardOverride?: Parti
             Object.assign(llmConfig, otherFields);
 
             const result = await agent.switchLLM(llmConfig, sessionId);
+            // Mask apiKey in result if present
+            if (result && result.config && result.config.apiKey) {
+                result.config.apiKey = '[REDACTED]';
+            }
             return res.json(result);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -450,7 +450,7 @@ export async function initializeApi(agent: SaikiAgent, agentCardOverride?: Parti
                 : agent.getCurrentLLMConfig();
 
             // Mask apiKey before returning
-            if (currentConfig && currentConfig.apiKey) {
+            if (currentConfig?.apiKey) {
                 currentConfig.apiKey = '[REDACTED]';
             }
 
@@ -514,7 +514,7 @@ export async function initializeApi(agent: SaikiAgent, agentCardOverride?: Parti
 
             const result = await agent.switchLLM(llmConfig, sessionId);
             // Mask apiKey in result if present
-            if (result && result.config && result.config.apiKey) {
+            if (result?.config?.apiKey) {
                 result.config.apiKey = '[REDACTED]';
             }
             return res.json(result);


### PR DESCRIPTION
Closes #236 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * API responses for LLM configuration now mask the API key field to prevent exposure of sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->